### PR TITLE
Add Auth0 configuration files

### DIFF
--- a/auth0/.gitignore
+++ b/auth0/.gitignore
@@ -1,0 +1,1 @@
+config.json

--- a/auth0/Makefile
+++ b/auth0/Makefile
@@ -1,0 +1,8 @@
+setup:
+	npm i -g auth0-deploy-cli
+
+deploy:
+	a0deploy import --config_file config.json --input_file .
+
+export:
+	a0deploy export --config_file config.json --format directory --output_folder .

--- a/auth0/README.md
+++ b/auth0/README.md
@@ -1,0 +1,26 @@
+# Auth0 Tenant Configuration
+
+This folder specifies the configuration of the Auth0 tenant used by the
+Case Law Editorial UI. It uses the [Auth0 CLI Deployment tool](https://github.com/auth0/auth0-deploy-cli)
+to manage and maintain a versioned configuration.
+
+For full details of what can be set in the files here, see the
+[example](https://github.com/auth0/auth0-deploy-cli/tree/master/examples/directory).
+
+## Setup
+
+Copy `config.example.json` to `config.json` and set the Client ID and
+Secret from the `auth0-deploy-cli-extension` application in Auth0.
+
+Run `make setup` to install the CLI tool.
+
+## Deployment
+
+To deploy the configuration, run `make deploy`.
+
+Note that deletions are disabled.
+
+## Export
+
+To save the remote Auth0 configuration as JSON files in this directory,
+run `make export`.

--- a/auth0/attack-protection/breached-password-detection.json
+++ b/auth0/attack-protection/breached-password-detection.json
@@ -1,0 +1,6 @@
+{
+  "enabled": false,
+  "shields": [],
+  "admin_notification_frequency": [],
+  "method": "standard"
+}

--- a/auth0/attack-protection/brute-force-protection.json
+++ b/auth0/attack-protection/brute-force-protection.json
@@ -1,0 +1,10 @@
+{
+  "enabled": true,
+  "shields": [
+    "block",
+    "user_notification"
+  ],
+  "mode": "count_per_identifier_and_ip",
+  "allowlist": [],
+  "max_attempts": 10
+}

--- a/auth0/attack-protection/suspicious-ip-throttling.json
+++ b/auth0/attack-protection/suspicious-ip-throttling.json
@@ -1,0 +1,18 @@
+{
+  "enabled": true,
+  "shields": [
+    "admin_notification",
+    "block"
+  ],
+  "allowlist": [],
+  "stage": {
+    "pre-login": {
+      "max_attempts": 100,
+      "rate": 864000
+    },
+    "pre-user-registration": {
+      "max_attempts": 50,
+      "rate": 1200
+    }
+  }
+}

--- a/auth0/clients/auth0-deploy-cli-extension.json
+++ b/auth0/clients/auth0-deploy-cli-extension.json
@@ -1,0 +1,28 @@
+{
+  "is_token_endpoint_ip_header_trusted": false,
+  "name": "auth0-deploy-cli-extension",
+  "is_first_party": true,
+  "oidc_conformant": true,
+  "sso_disabled": false,
+  "cross_origin_auth": false,
+  "refresh_token": {
+    "expiration_type": "non-expiring",
+    "leeway": 0,
+    "infinite_token_lifetime": true,
+    "infinite_idle_token_lifetime": true,
+    "token_lifetime": 31557600,
+    "idle_token_lifetime": 2592000,
+    "rotation_type": "non-rotating"
+  },
+  "jwt_configuration": {
+    "alg": "RS256",
+    "lifetime_in_seconds": 36000,
+    "secret_encoded": false
+  },
+  "token_endpoint_auth_method": "client_secret_post",
+  "app_type": "non_interactive",
+  "grant_types": [
+    "client_credentials"
+  ],
+  "custom_login_page_on": true
+}

--- a/auth0/clients/production.json
+++ b/auth0/clients/production.json
@@ -1,6 +1,7 @@
 {
   "is_token_endpoint_ip_header_trusted": false,
   "name": "production",
+  "description": "Case Law Editorial",
   "app_type": "regular_web",
   "callbacks": [],
   "is_first_party": true,
@@ -27,5 +28,8 @@
     "refresh_token",
     "client_credentials"
   ],
-  "custom_login_page_on": true
+  "custom_login_page_on": true,
+  "web_origins": [
+    "https://editor.caselaw.nationalarchives.gov.uk"
+	]
 }

--- a/auth0/clients/production.json
+++ b/auth0/clients/production.json
@@ -1,0 +1,31 @@
+{
+  "is_token_endpoint_ip_header_trusted": false,
+  "name": "production",
+  "app_type": "regular_web",
+  "callbacks": [],
+  "is_first_party": true,
+  "oidc_conformant": true,
+  "sso_disabled": false,
+  "cross_origin_auth": false,
+  "refresh_token": {
+    "expiration_type": "non-expiring",
+    "leeway": 0,
+    "infinite_token_lifetime": true,
+    "infinite_idle_token_lifetime": true,
+    "token_lifetime": 2592000,
+    "idle_token_lifetime": 1296000,
+    "rotation_type": "non-rotating"
+  },
+  "jwt_configuration": {
+    "alg": "RS256",
+    "lifetime_in_seconds": 36000,
+    "secret_encoded": false
+  },
+  "grant_types": [
+    "authorization_code",
+    "implicit",
+    "refresh_token",
+    "client_credentials"
+  ],
+  "custom_login_page_on": true
+}

--- a/auth0/clients/staging.json
+++ b/auth0/clients/staging.json
@@ -1,6 +1,7 @@
 {
   "is_token_endpoint_ip_header_trusted": false,
   "name": "staging",
+  "description": "Case Law Editorial (Staging)",
   "app_type": "regular_web",
   "callbacks": [],
   "is_first_party": true,
@@ -27,5 +28,9 @@
     "refresh_token",
     "client_credentials"
   ],
-  "custom_login_page_on": true
+  "custom_login_page_on": true,
+  "web_origins": [
+    "https://editor.staging.caselaw.nationalarchives.gov.uk",
+		"https://editor.staging.caselaw-stg.dalmatian.dxw.net"
+	]
 }

--- a/auth0/clients/staging.json
+++ b/auth0/clients/staging.json
@@ -1,0 +1,31 @@
+{
+  "is_token_endpoint_ip_header_trusted": false,
+  "name": "staging",
+  "app_type": "regular_web",
+  "callbacks": [],
+  "is_first_party": true,
+  "oidc_conformant": true,
+  "sso_disabled": false,
+  "cross_origin_auth": false,
+  "refresh_token": {
+    "expiration_type": "non-expiring",
+    "leeway": 0,
+    "infinite_token_lifetime": true,
+    "infinite_idle_token_lifetime": true,
+    "token_lifetime": 2592000,
+    "idle_token_lifetime": 1296000,
+    "rotation_type": "non-rotating"
+  },
+  "jwt_configuration": {
+    "alg": "RS256",
+    "lifetime_in_seconds": 36000,
+    "secret_encoded": false
+  },
+  "grant_types": [
+    "authorization_code",
+    "implicit",
+    "refresh_token",
+    "client_credentials"
+  ],
+  "custom_login_page_on": true
+}

--- a/auth0/config.example.json
+++ b/auth0/config.example.json
@@ -1,0 +1,16 @@
+{
+  "AUTH0_DOMAIN": "tna-caselaw-editorial-team.eu.auth0.com",
+  "AUTH0_CLIENT_ID": "<client_id>",
+  "AUTH0_CLIENT_SECRET": "<client_secret>",
+  "AUTH0_KEYWORD_REPLACE_MAPPINGS": {
+  },
+  "AUTH0_ALLOW_DELETE": false,
+  "AUTH0_EXCLUDED_RULES": [
+  ],
+  "INCLUDED_PROPS": {
+    "clients": [ ]
+  },
+  "EXCLUDED_PROPS": {
+    "connections": [ "options.client_secret" ]
+  }
+}

--- a/auth0/database-connections/Username-Password-Authentication/database.json
+++ b/auth0/database-connections/Username-Password-Authentication/database.json
@@ -1,0 +1,21 @@
+{
+  "options": {
+    "mfa": {
+      "active": true,
+      "return_enroll_settings": true
+    },
+    "passwordPolicy": "good",
+    "strategy_version": 2,
+    "brute_force_protection": true
+  },
+  "strategy": "auth0",
+  "name": "Username-Password-Authentication",
+  "is_domain_connection": false,
+  "realms": [
+    "Username-Password-Authentication"
+  ],
+  "enabled_clients": [
+    "staging",
+    "production"
+  ]
+}

--- a/auth0/database-connections/Username-Password-Authentication/database.json
+++ b/auth0/database-connections/Username-Password-Authentication/database.json
@@ -6,7 +6,8 @@
     },
     "passwordPolicy": "good",
     "strategy_version": 2,
-    "brute_force_protection": true
+    "brute_force_protection": true,
+    "disable_signup": true
   },
   "strategy": "auth0",
   "name": "Username-Password-Authentication",

--- a/auth0/tenant.json
+++ b/auth0/tenant.json
@@ -1,0 +1,12 @@
+{
+  "enabled_locales": [
+    "en"
+  ],
+  "flags": {
+    "universal_login": true,
+    "revoke_refresh_token_grant": false,
+    "disable_clickjack_protection_headers": false
+  },
+  "idle_session_lifetime": 72,
+  "session_lifetime": 180
+}

--- a/auth0/tenant.json
+++ b/auth0/tenant.json
@@ -1,4 +1,5 @@
 {
+  "friendly_name": "Case Law Editorial Team",
   "enabled_locales": [
     "en"
   ],


### PR DESCRIPTION
Using the Auth0 deployment CLI, we can set up the tenant fully from versioned JSON instead of by clicking things in the UI. This is a good thing.