### PR TITLE
Add Jim's improved search query to marklogic module DB

### DIFF
--- a/marklogic/src/main/ml-modules/root/judgments/search/helper.xqy
+++ b/marklogic/src/main/ml-modules/root/judgments/search/helper.xqy
@@ -1,0 +1,114 @@
+xquery version "1.0-ml";
+
+module namespace helper = "https://caselaw.nationalarchives.gov.uk/helper";
+
+import module namespace ml = "http://marklogic.com/appservices/search" at "/MarkLogic/appservices/search/search.xqy";
+
+declare namespace akn = "http://docs.oasis-open.org/legaldocml/ns/akn/3.0";
+declare namespace uk = "https://caselaw.nationalarchives.gov.uk";
+
+declare private function remove-quotes($s as xs:string) as xs:string {
+    fn:translate($s, '"', '')
+};
+
+declare private function make-name-query($q as xs:string) as cts:query {
+    let $element as xs:QName := fn:QName('http://docs.oasis-open.org/legaldocml/ns/akn/3.0', 'FRBRname')
+    let $attribute as xs:QName := fn:QName('', 'value')
+    let $options as xs:string* := ()
+    let $weight as xs:double := 32.0
+    return cts:and-query((
+        for $phrase at $pos in fn:tokenize($q, '"')
+            let $inside-quotes as xs:boolean := $pos mod 2 eq 0
+            return if ($inside-quotes) then
+                cts:element-attribute-word-query($element, $attribute, $phrase, $options, $weight)
+            else for $word in fn:tokenize(fn:normalize-space($phrase), '\s')
+                return cts:element-attribute-word-query($element, $attribute, $word, $options, $weight)
+    ))
+};
+
+declare private function make-cite-query($q as xs:string) as cts:query {
+    let $phrase as xs:string := remove-quotes($q)
+    let $element as xs:QName := fn:QName('https://caselaw.nationalarchives.gov.uk/akn', 'cite')
+    let $options as xs:string* := ( 'case-insensitive' )
+    let $weight as xs:double := 32.0
+    return cts:element-word-query($element, $phrase, $options, $weight)
+};
+
+declare function make-court-query($court as xs:string) as cts:query {
+    let $element as xs:QName := fn:QName('https://caselaw.nationalarchives.gov.uk/akn', 'court')
+    let $options as xs:string* := ( 'case-insensitive' )
+    return cts:element-value-query($element, $court, $options)
+};
+
+declare private function make-phrase-query($q as xs:string) as cts:query? {
+    if (fn:contains($q, '"')) then
+        ()
+    else
+        let $phrase as xs:string := remove-quotes($q)
+        return cts:word-query($phrase, (), 16.0)
+};
+
+declare private function make-simple-q-query($q as xs:string) as cts:query {
+    cts:and-query((
+        for $phrase at $pos in fn:tokenize($q, '"')
+            let $inside-quotes as xs:boolean := $pos mod 2 eq 0
+            return
+                if ($inside-quotes) then
+                    cts:word-query($phrase)
+                else
+                    let $words as xs:string* := fn:tokenize(fn:normalize-space($phrase), '\s')
+                    return (
+                        for $word in $words
+                            return cts:word-query($word),
+                        if (fn:exists($words)) then cts:word-query($words, 'distance-weight=16') else ()
+                    )
+    ))
+};
+
+declare function make-q-query($q as xs:string) as cts:query {
+     cts:or-query((
+        make-name-query($q),
+        make-cite-query($q),
+        make-phrase-query($q),
+        make-simple-q-query($q)
+     ))
+};
+
+declare function make-party-query($party as xs:string?) as cts:query? {
+    if ($party) then cts:or-query((
+        cts:element-word-query(fn:QName('http://docs.oasis-open.org/legaldocml/ns/akn/3.0', 'party'), $party),
+        cts:element-attribute-word-query(fn:QName('http://docs.oasis-open.org/legaldocml/ns/akn/3.0', 'FRBRname'), fn:QName('', 'value'), $party)
+    )) else ()
+};
+
+declare variable $transform-results :=
+    <transform-results xmlns="http://marklogic.com/appservices/search" apply="snippet" ns="https://caselaw.nationalarchives.gov.uk/helper" at="/helper.xqy">
+        <preferred-matches>
+            <element name="p" ns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"/>
+        </preferred-matches>
+    </transform-results>;
+
+declare function snippet($result as node(), $query as schema-element(cts:query), $options as element(ml:transform-results)?) as element(ml:snippet) {
+    let $unfiltered := ml:snippet($result, $query, $options)
+    return xdmp:xslt-eval($snippet-filter, $unfiltered)/*
+};
+
+declare private variable $snippet-filter := <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" xmlns:search="http://marklogic.com/appservices/search">
+    <xsl:template match="search:match">
+        <xsl:choose>
+            <xsl:when test="empty(child::node())" />
+            <xsl:when test="ends-with(@path, 'court')" />
+            <xsl:when test="ends-with(@path, 'year')" />
+            <xsl:when test="ends-with(@path, 'number')" />
+            <xsl:when test="ends-with(@path, 'cite') and exists(following-sibling::*)" />
+            <xsl:otherwise>
+                <xsl:next-match />
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+    <xsl:template match="@*|node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+</xsl:stylesheet>;

--- a/marklogic/src/main/ml-modules/root/judgments/search/search.xqy
+++ b/marklogic/src/main/ml-modules/root/judgments/search/search.xqy
@@ -1,0 +1,99 @@
+xquery version "1.0-ml";
+
+import module namespace search = "http://marklogic.com/appservices/search" at "/MarkLogic/appservices/search/search.xqy";
+import module namespace dls = "http://marklogic.com/xdmp/dls" at "/MarkLogic/dls.xqy";
+declare namespace akn = "http://docs.oasis-open.org/legaldocml/ns/akn/3.0";
+declare namespace uk = "https://caselaw.nationalarchives.gov.uk";
+
+declare function uk:get-request-date($name as xs:string) as xs:date? {
+    let $raw := $name
+    return if ($raw castable as xs:date) then xs:date($raw) else ()
+};
+
+declare variable $q as xs:string? external;
+declare variable $party as xs:string? external;
+declare variable $court as xs:string? external;
+declare variable $judge as xs:string? external;
+declare variable $order as xs:string? external;
+declare variable $page as xs:integer external;
+declare variable $page-size as xs:integer external;
+declare variable $from as xs:string? external;
+declare variable $to as xs:string? external;
+declare variable $from_date as xs:date? := uk:get-request-date($from);
+declare variable $to_date as xs:date? := uk:get-request-date($to);
+declare variable $show_unpublished as xs:boolean? external;
+
+let $start as xs:integer := ($page - 1) * $page-size + 1
+
+let $params := map:map()
+    => map:with('q', $q)
+    => map:with('party', $party)
+    => map:with('court', $court)
+    => map:with('judge', $judge)
+    => map:with('page', $page)
+    => map:with('page-size', $page-size)
+    => map:with('order', $order)
+    => map:with('from',$from)
+    => map:with('to', $to)
+    => map:with('show_unpublished', $show_unpublished)
+
+let $query1 := if ($q) then cts:word-query($q) else ()
+let $query2 := if ($party) then
+    cts:or-query((
+        cts:element-word-query(fn:QName('http://docs.oasis-open.org/legaldocml/ns/akn/3.0', 'party'), $party),
+        cts:element-attribute-word-query(fn:QName('http://docs.oasis-open.org/legaldocml/ns/akn/3.0', 'FRBRname'), fn:QName('', 'value'), $party)
+    ))
+else ()
+let $query4 := if ($court) then cts:or-query((
+    cts:element-value-query(fn:QName('https://judgments.gov.uk/', 'court'), $court, ('case-insensitive')),
+    cts:element-value-query(fn:QName('https://caselaw.nationalarchives.gov.uk/akn', 'court'), $court, ('case-insensitive')),
+    cts:element-attribute-word-query(
+    fn:QName('http://docs.oasis-open.org/legaldocml/ns/akn/3.0', 'FRBRuri'), xs:QName('value'), $court, ('case-insensitive')
+    )
+)) else ()
+let $query5 := if ($judge) then cts:element-word-query(fn:QName('http://docs.oasis-open.org/legaldocml/ns/akn/3.0', 'judge'), $judge) else ()
+let $query6 := if (empty($from_date)) then () else cts:path-range-query('akn:FRBRWork/akn:FRBRdate/@date', '>=', $from_date)
+let $query7 := if (empty($to_date)) then () else cts:path-range-query('akn:FRBRWork/akn:FRBRdate/@date', '<=', $to_date)
+let $query8 := if ($show_unpublished) then () else cts:properties-fragment-query(cts:element-value-query(fn:QName("", "published"), "true"))
+
+let $queries := ( $query1, $query2, $query4, $query5, $query6, $query7, $query8, dls:documents-query() )
+let $query := cts:and-query($queries)
+
+let $show-snippets as xs:boolean := exists(( $query1, $query2, $query5 ))
+
+let $sort-order := if ($order = 'date') then
+    <sort-order xmlns="http://marklogic.com/appservices/search" direction="ascending">
+        <path-index xmlns:akn="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">akn:FRBRWork/akn:FRBRdate/@date</path-index>
+    </sort-order>
+else if ($order = '-date') then
+    <sort-order xmlns="http://marklogic.com/appservices/search" direction="descending">
+        <path-index xmlns:akn="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">akn:FRBRWork/akn:FRBRdate/@date</path-index>
+    </sort-order>
+else
+    ()
+
+let $transform-results := if ($show-snippets) then
+    <transform-results apply="snippet">
+        <preferred-matches>
+            <element name="p" ns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"/>
+        </preferred-matches>
+    </transform-results>
+else
+    <transform-results apply="empty-snippet" />
+
+let $search-options := <options xmlns="http://marklogic.com/appservices/search">
+    { $sort-order }
+    <extract-document-data xmlns:akn="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">
+        <extract-path>//akn:FRBRWork/akn:FRBRname</extract-path>
+        <extract-path>//akn:neutralCitation</extract-path>
+        <extract-path>//akn:FRBRWork/akn:FRBRdate</extract-path>
+    </extract-document-data>
+    { $transform-results }
+</options>
+
+let $results := search:resolve($query, $search-options, $start, $page-size)
+let $total as xs:integer := xs:integer($results/@total)
+let $pages as xs:integer := if ($total mod $page-size eq 0) then $total idiv $page-size else $total idiv $page-size + 1
+let $params := $params => map:with('pages', $pages)
+
+return $results

--- a/marklogic/src/main/ml-modules/root/judgments/search/search.xqy
+++ b/marklogic/src/main/ml-modules/root/judgments/search/search.xqy
@@ -1,6 +1,7 @@
 xquery version "1.0-ml";
 
 import module namespace search = "http://marklogic.com/appservices/search" at "/MarkLogic/appservices/search/search.xqy";
+import module namespace helper = "https://caselaw.nationalarchives.gov.uk/helper" at "./helper.xqy";
 import module namespace dls = "http://marklogic.com/xdmp/dls" at "/MarkLogic/dls.xqy";
 declare namespace akn = "http://docs.oasis-open.org/legaldocml/ns/akn/3.0";
 declare namespace uk = "https://caselaw.nationalarchives.gov.uk";
@@ -33,11 +34,11 @@ let $params := map:map()
     => map:with('page', $page)
     => map:with('page-size', $page-size)
     => map:with('order', $order)
-    => map:with('from',$from)
+    => map:with('from', $from)
     => map:with('to', $to)
     => map:with('show_unpublished', $show_unpublished)
 
-let $query1 := if ($q) then cts:word-query($q) else ()
+let $query1 := if ($q) then helper:make-q-query($q) else ()
 let $query2 := if ($party) then
     cts:or-query((
         cts:element-word-query(fn:QName('http://docs.oasis-open.org/legaldocml/ns/akn/3.0', 'party'), $party),
@@ -73,20 +74,17 @@ else
     ()
 
 let $transform-results := if ($show-snippets) then
-    <transform-results apply="snippet">
-        <preferred-matches>
-            <element name="p" ns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"/>
-        </preferred-matches>
-    </transform-results>
+    $helper:transform-results
 else
-    <transform-results apply="empty-snippet" />
+    <transform-results xmlns="http://marklogic.com/appservices/search" apply="empty-snippet" />
 
 let $search-options := <options xmlns="http://marklogic.com/appservices/search">
     { $sort-order }
-    <extract-document-data xmlns:akn="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">
-        <extract-path>//akn:FRBRWork/akn:FRBRname</extract-path>
-        <extract-path>//akn:neutralCitation</extract-path>
+    <extract-document-data xmlns:akn="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
         <extract-path>//akn:FRBRWork/akn:FRBRdate</extract-path>
+        <extract-path>//akn:FRBRWork/akn:FRBRname</extract-path>
+        <extract-path>//uk:cite</extract-path>
+        <extract-path>//akn:neutralCitation</extract-path>
     </extract-document-data>
     { $transform-results }
 </options>


### PR DESCRIPTION
Rather than uploading every time, we can store the search xquery in the modules database and load it with gradle. 

There are two commits to help with review. The first is the query as currently exists in the custom API client code, which includes some modifications we've made for DLS and collections. The second commit adds Jim's changes. The diff should be the same as https://github.com/mangiafico/tna-judgments-website/commit/e1d7081ebea9cac84d4d0e74024dc691d1516c83, though the end result file is slightly different because of our diverged query.