### PR TITLE
Do not show unsupported non-web images in Judgments

### DIFF
--- a/marklogic/src/main/ml-modules/root/judgments/xslts/judgment2.xsl
+++ b/marklogic/src/main/ml-modules/root/judgments/xslts/judgment2.xsl
@@ -295,10 +295,12 @@
 </xsl:template>
 
 <xsl:template match="img">
-	<img>
-		<xsl:apply-templates select="@*" />
-		<xsl:apply-templates />
-	</img>
+	<xsl:if test="matches(@src, '\.gif|\.png|\.jpg|\.jpeg|\.webp|\.svg')">
+		<img>
+			<xsl:apply-templates select="@*" />
+			<xsl:apply-templates />
+		</img>
+	</xsl:if>
 </xsl:template>
 <xsl:template match="img/@src">
 	<xsl:attribute name="src">


### PR DESCRIPTION
Some of the Judgments/decisions contain images which are not web formats, e.g.
.emf or .wmf

These formats are not viewable in a browser and cause an error when the
judgment is downloaded as a PDF.

Amend the XSL transform to only show web formats (png, gif, jpg) and ignore
any others.

Ideally, we will need Clerks to only submit images in judgments which are
web-compatible, or we will need to convert non-web images somewhow as part
of the ingestion service.

Rollbar report: https://rollbar.com/dxw/tna-caselaw-public-ui/items/27/

Previously referenced in: https://github.com/nationalarchives/ds-caselaw-public-ui/pull/123