### PR TITLE
Enable search results with dates to be "snippeted" for search results

### DIFF
--- a/marklogic/src/main/ml-modules/root/judgments/search/search.xqy
+++ b/marklogic/src/main/ml-modules/root/judgments/search/search.xqy
@@ -121,7 +121,7 @@ let $search-options := <options xmlns="http://marklogic.com/appservices/search">
     { $transform-results }
 </options>
 
-let $results := search:resolve($query, $search-options, $start, $page-size)
+let $results := search:resolve(element x { $query }/*, $search-options, $start, $page-size)
 let $total as xs:integer := xs:integer($results/@total)
 let $pages as xs:integer := if ($total mod $page-size eq 0) then $total idiv $page-size else $total idiv $page-size + 1
 let $params := $params => map:with('pages', $pages)


### PR DESCRIPTION
Rollbar: https://rollbar.com/dxw/tna-caselaw-public-ui/items/26/

This very obscure error was occurring when users searched for judgments with
to and from dates as part of the search parameters. The `snippet` functionality
in Marklogic was not able to handle search results from date searches due to
missing the `akn` namespace when formatting results.

Fix supplied by jurisdatum

Co-Authored-By: jurisdatum <jim@jurisdatum.com>