### PR TITLE
improve queries containing '- v -'

### DIFF
--- a/marklogic/src/main/ml-modules/root/judgments/search/helper.xqy
+++ b/marklogic/src/main/ml-modules/root/judgments/search/helper.xqy
@@ -143,6 +143,7 @@ declare private function match-neutral-citation($phrase as xs:string) as element
 };
 
 declare function make-q-query($q as xs:string) {
+    let $q := fn:replace($q, '- *v *-', ' v ', 'i')
     let $q := fn:normalize-space($q)
     return cts:and-query((
         for $phrase at $pos in fn:tokenize($q, '"')

--- a/marklogic/src/main/ml-modules/root/judgments/xslts/judgment0.xsl
+++ b/marklogic/src/main/ml-modules/root/judgments/xslts/judgment0.xsl
@@ -9,7 +9,7 @@
 	xmlns:xs="http://www.w3.org/2001/XMLSchema"
 	exclude-result-prefixes="uk1 uk html math xs">
 
-<xsl:output method="html" encoding="utf-8" indent="yes" include-content-type="no" />
+<xsl:output method="html" encoding="utf-8" indent="no" include-content-type="no" />
 
 <xsl:strip-space elements="*" />
 <xsl:preserve-space elements="p block num heading span a courtType date docDate docTitle docketNumber judge lawyer location neutralCitation party role time" />


### PR DESCRIPTION
This is a small change to improve queries containing dashes around the "v", as requested by Rose