### PR TITLE
Change output indenting from `yes` to `no`

### DIFF
--- a/marklogic/src/main/ml-modules/root/judgments/xslts/judgment0.xsl
+++ b/marklogic/src/main/ml-modules/root/judgments/xslts/judgment0.xsl
@@ -9,7 +9,7 @@
 	xmlns:xs="http://www.w3.org/2001/XMLSchema"
 	exclude-result-prefixes="uk1 uk html math xs">
 
-<xsl:output method="html" encoding="utf-8" indent="yes" include-content-type="no" />
+<xsl:output method="html" encoding="utf-8" indent="no" include-content-type="no" />
 
 <xsl:strip-space elements="*" />
 <xsl:preserve-space elements="p block num heading span a courtType date docDate docTitle docketNumber judge lawyer location neutralCitation party role time" />


### PR DESCRIPTION
Output indenting can cause extra spaces to appear in the HTML output.