### PR TITLE
Exclude html `style` elements from word queries

### DIFF
--- a/marklogic/src/main/ml-config/databases/content-database.json
+++ b/marklogic/src/main/ml-config/databases/content-database.json
@@ -19,5 +19,16 @@
     "invalid-values": "reject"
   } ], 
   "word-positions": true,
-  "maintain-last-modified": true
+  "maintain-last-modified": true,
+  "field" : [ {
+    "field-name" : "",
+    "include-root" : true,
+    "excluded-element" : [ {
+      "namespace-uri" : "http://www.w3.org/1999/xhtml",
+      "localname" : "style",
+      "attribute-namespace-uri" : "",
+      "attribute-localname" : "",
+      "attribute-value" : ""
+    } ]
+  } ]
 }


### PR DESCRIPTION
Trello: https://trello.com/c/KbLYDZi9

Exclude the contents of the html `style` tag from word queries, as it may contain
text that matches searches, but is irrelevant in terms of content.