### PR TITLE
Restrict rendered image types to web-safe images (attempt 2)

### DIFF
--- a/marklogic/src/main/ml-modules/root/judgments/xslts/judgment0.xsl
+++ b/marklogic/src/main/ml-modules/root/judgments/xslts/judgment0.xsl
@@ -335,7 +335,7 @@ body { margin: 1cm 1in }
 </xsl:template>
 
 <xsl:template match="img">
-	<xsl:if test="matches(@src, '\.gif|\.png|\.jpg|\.jpeg|\.webp|\.svg|\.bmp')">
+	<xsl:if test="matches(@src, '\.gif$|\.png$|\.jpg$|\.jpeg$|\.webp$|\.svg$|\.bmp$')">
 		<img>
 			<xsl:apply-templates select="@*" />
 			<xsl:apply-templates />

--- a/marklogic/src/main/ml-modules/root/judgments/xslts/judgment0.xsl
+++ b/marklogic/src/main/ml-modules/root/judgments/xslts/judgment0.xsl
@@ -335,10 +335,12 @@ body { margin: 1cm 1in }
 </xsl:template>
 
 <xsl:template match="img">
-	<img>
-		<xsl:apply-templates select="@*" />
-		<xsl:apply-templates />
-	</img>
+	<xsl:if test="matches(@src, '\.gif|\.png|\.jpg|\.jpeg|\.webp|\.svg|\.bmp')">
+		<img>
+			<xsl:apply-templates select="@*" />
+			<xsl:apply-templates />
+		</img>
+	</xsl:if>
 </xsl:template>
 <xsl:template match="img/@src">
 	<xsl:attribute name="src">

--- a/marklogic/src/main/ml-modules/root/judgments/xslts/judgment2.xsl
+++ b/marklogic/src/main/ml-modules/root/judgments/xslts/judgment2.xsl
@@ -295,7 +295,7 @@
 </xsl:template>
 
 <xsl:template match="img">
-	<xsl:if test="matches(@src, '\.gif|\.png|\.jpg|\.jpeg|\.webp|\.svg')">
+	<xsl:if test="matches(@src, '\.gif|\.png|\.jpg|\.jpeg|\.webp|\.svg|\.bmp')">
 		<img>
 			<xsl:apply-templates select="@*" />
 			<xsl:apply-templates />

--- a/marklogic/src/main/ml-modules/root/judgments/xslts/judgment2.xsl
+++ b/marklogic/src/main/ml-modules/root/judgments/xslts/judgment2.xsl
@@ -295,7 +295,7 @@
 </xsl:template>
 
 <xsl:template match="img">
-	<xsl:if test="matches(@src, '\.gif|\.png|\.jpg|\.jpeg|\.webp|\.svg|\.bmp')">
+	<xsl:if test="matches(@src, '\.gif$|\.png$|\.jpg$|\.jpeg$|\.webp$|\.svg$|\.bmp$')">
 		<img>
 			<xsl:apply-templates select="@*" />
 			<xsl:apply-templates />


### PR DESCRIPTION
We should only allow the transform to show web-safe image types, gif, jpg, png, svg, bmp, webp and not emf/wmf which are sometimes in judgments.