### PR TITLE
OpenAPI: add pagination and make feed valid

### DIFF
--- a/doc/openapi/public_api.yml
+++ b/doc/openapi/public_api.yml
@@ -2,7 +2,7 @@ openapi: '3.0.3'
 
 info:
   title: Case Law Public API
-  version: '0.1'
+  version: '0.1.1'
 
 servers:
 - url: https://{environment}.nationalarchives.gov.uk/
@@ -87,6 +87,12 @@ paths:
               - updated
               - -updated
             default: -date
+        - name: page
+          required: false
+          in: query
+          schema:
+            type: integer
+            default: 1
       responses:
         '200':
           $ref: "#/components/responses/judgmentFeed"

--- a/doc/openapi/public_api.yml
+++ b/doc/openapi/public_api.yml
@@ -47,25 +47,35 @@ components:
             description: Akoma Ntoso
 
 paths:
-  /[{court}/[[{subdivision}/]{year}/]]atom.xml:
+  /{court}/{subdivision}/{year}/atom.xml:
     get:
       summary: Get recently published or updated judgments
+      description: >
+        Less specific feeds can be gained by omitting the components
+        e.g. /, /2022/, /ewhc/ and /ewhc/ch/ are all valid prefixes to atom.xml
+        Note that a {court} is required if there is a {subdivision}
       operationId: listJudgments
       tags:
         - Reading
       parameters:
         - name: court
-          required: false
+          required: true
           in: path
           example: ewca
+          schema:
+            type: string
         - name: subdivision
-          required: false
+          required: true
           in: path
           example: pat
+          schema:
+            type: string
         - name: year
-          required: false
+          required: true
           in: path
           example: 2022
+          schema:
+            type: integer
         - name: order
           required: false
           in: query

--- a/scripts/openapi/install_validator
+++ b/scripts/openapi/install_validator
@@ -1,0 +1,1 @@
+npm install -g @apidevtools/swagger-cli

--- a/scripts/openapi/validate
+++ b/scripts/openapi/validate
@@ -1,0 +1,4 @@
+set -e
+swagger-cli validate $* doc/openapi/public_api.yml
+swagger-cli validate $* doc/openapi/privileged_api.yml
+


### PR DESCRIPTION
[Trello Ticket](https://trello.com/c/nU4ZTiqN/644-openapi-yaml-fails-validation)

We used an optional path string in the OpenAPI spec but they don't actually exist.

Optional path strings are not a part of the OpenAPI spec but
have been a long-running request.

https://github.com/OAI/OpenAPI-Specification/issues/93

So we tell a small fib in the spec and say these paths are required,
(because they *have* to be required in the spec) but then
have a comment pointing out that /atom.xml etc are valid paths.

Additionally we add some scripts to install an OpenAPI validator
and to validate the two YAML documents. There is documentation
for doing this with pre-commit but I couldn't get that to work.