### PR TITLE
Generate HTML/Python versions of OpenAPI docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+generated

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This is the central repository for the [Case Law Public Access service](https://
 * [Ingester](https://github.com/nationalarchives/ds-caselaw-ingester)
 * [PDF conversion](https://github.com/nationalarchives/ds-caselaw-pdf-conversion)
 * [Marklogic database configuration](https://github.com/nationalarchives/ds-caselaw-public-access-service/tree/main/marklogic)
+* [OpenAPI spec](https://github.com/nationalarchives/ds-caselaw-public-access-service/tree/main/doc/openapi)
 
 ### Shared support libraries
 

--- a/doc/openapi/README.md
+++ b/doc/openapi/README.md
@@ -3,3 +3,4 @@ There are two APIs specified in OpenAPI yaml files.
 Generator tools and validators can be installed via `scripts/openapi/install`
 The YAML files can be validated with `scripts/openapi/validate`
 HTML versions can be generated in `/generated` via `scripts/openapi/create_html`
+Python code can be generated in `/python` via `scripts/openapi/create_python`

--- a/doc/openapi/README.md
+++ b/doc/openapi/README.md
@@ -1,0 +1,5 @@
+There are two APIs specified in OpenAPI yaml files.
+
+Generator tools and validators can be installed via `scripts/openapi/install`
+The YAML files can be validated with `scripts/openapi/validate`
+HTML versions can be generated in `/generated` via `scripts/openapi/create_html`

--- a/scripts/openapi/create_html
+++ b/scripts/openapi/create_html
@@ -1,2 +1,2 @@
-redoc-cli bundle -o generated/public_api.html doc/openapi/public_api.yml
-redoc-cli bundle -o generated/privileged_api.html doc/openapi/privileged_api.yml
+redoc-cli build -o generated/public_api.html doc/openapi/public_api.yml
+redoc-cli build -o generated/privileged_api.html doc/openapi/privileged_api.yml

--- a/scripts/openapi/create_html
+++ b/scripts/openapi/create_html
@@ -1,0 +1,2 @@
+redoc-cli bundle -o generated/public_api.html doc/openapi/public_api.yml
+redoc-cli bundle -o generated/privileged_api.html doc/openapi/privileged_api.yml

--- a/scripts/openapi/create_python
+++ b/scripts/openapi/create_python
@@ -1,0 +1,2 @@
+openapi-generator generate -i doc/openapi/public_api.yml -g python -o generated/public
+openapi-generator generate -i doc/openapi/privileged_api.yml -g python -o generated/privileged

--- a/scripts/openapi/create_python
+++ b/scripts/openapi/create_python
@@ -1,2 +1,2 @@
-openapi-generator generate -i doc/openapi/public_api.yml -g python -o generated/public
-openapi-generator generate -i doc/openapi/privileged_api.yml -g python -o generated/privileged
+openapi-generator generate -i doc/openapi/public_api.yml -g python -o generated/public --git-host github.com --git-user-id nationalarchives --git-repo-id ds-caselaw-public-ui
+openapi-generator generate -i doc/openapi/privileged_api.yml -g python -o generated/privileged --git-host github.com --git-user-id nationalarchives --git-repo-id ds-caselaw-privileged-api

--- a/scripts/openapi/generate_python
+++ b/scripts/openapi/generate_python
@@ -1,0 +1,2 @@
+openapi-generator generate -i doc/openapi/public_api.yml -g python -o generated/public
+openapi-generator generate -i doc/openapi/privileged_api.yml -g python -o generated/privileged

--- a/scripts/openapi/install
+++ b/scripts/openapi/install
@@ -1,0 +1,5 @@
+# validator
+npm install -g @apidevtools/swagger-cli
+
+# html version
+npm install -g redoc-cli

--- a/scripts/openapi/install_validator
+++ b/scripts/openapi/install_validator
@@ -1,1 +1,0 @@
-npm install -g @apidevtools/swagger-cli


### PR DESCRIPTION
`scripts/openapi/create_html` will create two HTML versions of the
OpenAPI specs in `generated`; `create_python` will do likewise for Python.

Many HTML generators exist, this one seems middling. I love the one at https://editor.swagger.io/ (powered by https://swagger.io/docs/open-source-tools/swagger-ui/usage/installation/ ) but that feels like too much work.