### PR TITLE
Sort by Manifested date

### DIFF
--- a/marklogic/src/main/ml-config/databases/content-database.json
+++ b/marklogic/src/main/ml-config/databases/content-database.json
@@ -10,6 +10,11 @@
     "path-expression" : "akn:FRBRWork/akn:FRBRdate/@date",
     "range-value-positions" : false,
     "invalid-values": "reject"
+  }, {
+    "scalar-type": "dateTime",
+    "path-expression" : "akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRManifestation/akn:FRBRdate[@name='transform']/@date",
+    "range-value-positions" : false,
+    "invalid-values": "ignore"
   } ],
   "range-element-index": [ {
     "scalar-type" : "dateTime",
@@ -17,7 +22,7 @@
     "localname": "last-modified",
     "range-value-positions" : false,
     "invalid-values": "reject"
-  } ], 
+  } ],
   "word-positions": true,
   "maintain-last-modified": true,
   "field" : [ {

--- a/marklogic/src/main/ml-modules/root/judgments/search/search.xqy
+++ b/marklogic/src/main/ml-modules/root/judgments/search/search.xqy
@@ -93,6 +93,14 @@ else if ($order = 'updated') then
     <sort-order xmlns="http://marklogic.com/appservices/search" direction="ascending" type="xs:dateTime">
         <element ns="http://marklogic.com/xdmp/property" name="last-modified" />
     </sort-order>
+else if ($order = '-transformation') then
+    <sort-order xmlns="http://marklogic.com/appservices/search" direction="ascending">
+        <path-index xmlns:akn="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRManifestation/akn:FRBRdate[@name='transform']/@date</path-index>
+    </sort-order>
+else if ($order = 'transformation') then
+    <sort-order xmlns="http://marklogic.com/appservices/search" direction="descending">
+        <path-index xmlns:akn="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRManifestation/akn:FRBRdate[@name='transform']/@date</path-index>
+    </sort-order>
 else
     ()
 


### PR DESCRIPTION
Potentially worth discussing the correct name for this date -- it might want to be "transformation" instead? Or something else entirely.

This is so we can sort by manifestation order for the atom feed
We have to look for the transformation date specifically because
there can be multiple dates in the Manifestation section of the document
for FRBRManifestation (and the long path is because there can be multiple documents with a Manifestation section each)

If we want to sort by Manifestation date for downstream consumers,
we need to index it.

We thought that invalid-values: ignore is required on that index because there is no manifestation date for newly ingested documents, causing errors like https://rollbar.com/dxw/tna-caselaw-ingester/items/42/?utm_campaign=new_item_message&utm_medium=slack&utm_source=rollbar-notification , but this also masked an issue where we used a date instead of a dateTime which
lead to it indexing everything as "not a date" (we think)