### PR TITLE
Add a custom dictionay stem for race/racial

### DIFF
--- a/marklogic/src/main/ml-modules/root/judgments/corb/set-custom-dictionary-stem.xqy
+++ b/marklogic/src/main/ml-modules/root/judgments/corb/set-custom-dictionary-stem.xqy
@@ -1,0 +1,13 @@
+xquery version "1.0-ml";
+
+import module namespace cdict = "http://marklogic.com/xdmp/custom-dictionary"
+  at "/MarkLogic/custom-dictionary.xqy";
+
+let $dict :=
+  <cdict:dictionary xmlns:cdict="http://marklogic.com/xdmp/custom-dictionary">
+    <cdict:entry>
+      <cdict:word>racial</cdict:word>
+      <cdict:stem>race</cdict:stem>
+    </cdict:entry>
+  </cdict:dictionary>
+return cdict:dictionary-write("en", $dict)


### PR DESCRIPTION
https://trello.com/c/d9YJkyA0

As part of adding stemmed & unstemmed seaches, we need to teach Marklogic that
the stem of "racial" is "race". Marklogic does not know this by default.

This XQuery achieves this, and needs to be run when the database is created or
updated.