### PR TITLE
Add a dictionary stem for discriminatory/discrimination

### DIFF
--- a/marklogic/src/main/ml-modules/root/judgments/corb/set-custom-dictionary-stem.xqy
+++ b/marklogic/src/main/ml-modules/root/judgments/corb/set-custom-dictionary-stem.xqy
@@ -9,5 +9,9 @@ let $dict :=
       <cdict:word>racial</cdict:word>
       <cdict:stem>race</cdict:stem>
     </cdict:entry>
+    <cdict:entry>
+      <cdict:word>discriminatory</cdict:word>
+      <cdict:stem>discrimination</cdict:stem>
+    </cdict:entry>
   </cdict:dictionary>
 return cdict:dictionary-write("en", $dict)


### PR DESCRIPTION
Marklogic isn't smart enough to know that the stem of "discriminatory" is
"discrimination", so we need to teach it.