### PR TITLE
two small bug fixes: no <hr> if no footnotes, space in empty <span> for tabs

### DIFF
--- a/marklogic/src/main/ml-modules/root/judgments/xslts/judgment0.xsl
+++ b/marklogic/src/main/ml-modules/root/judgments/xslts/judgment0.xsl
@@ -435,7 +435,9 @@ body { margin: 1cm 1in }
 <!-- markers and attributes -->
 
 <xsl:template match="marker[@name='tab']">
-	<span class="tab"> </span>
+	<span class="tab">
+		<xsl:text> </xsl:text>
+	</span>
 </xsl:template>
 
 <xsl:template match="@class | @style | @src | @href | @title">

--- a/marklogic/src/main/ml-modules/root/judgments/xslts/judgment0.xsl
+++ b/marklogic/src/main/ml-modules/root/judgments/xslts/judgment0.xsl
@@ -156,7 +156,7 @@ body { margin: 1cm 1in }
 		<xsl:apply-templates />
 		<xsl:apply-templates select="attachments/attachment/doc[@name=('annex','schedule')]" />
 		<xsl:call-template name="footnotes">
-			<xsl:with-param name="footnotes">
+			<xsl:with-param name="footnotes" as="element()*">
 				<xsl:sequence select="header//authorialNote" />
 				<xsl:sequence select="judgmentBody//authorialNote" />
 				<xsl:sequence select="attachments/attachment/doc[@name=('annex','schedule')]//authorialNote" />
@@ -456,8 +456,8 @@ body { margin: 1cm 1in }
 </xsl:template>
 
 <xsl:template name="footnotes">
-	<xsl:param name="footnotes" select="descendant::authorialNote" />
-	<xsl:if test="$footnotes">
+	<xsl:param name="footnotes" as="element()*" select="descendant::authorialNote" />
+	<xsl:if test="exists($footnotes)">
 		<footer class="footnotes">
 			<hr style="margin-top:2em" />
 			<xsl:apply-templates select="$footnotes" mode="footnote" />

--- a/marklogic/src/main/ml-modules/root/judgments/xslts/judgment2.xsl
+++ b/marklogic/src/main/ml-modules/root/judgments/xslts/judgment2.xsl
@@ -394,7 +394,9 @@
 <!-- markers and attributes -->
 
 <xsl:template match="marker[@name='tab']">
-	<span> </span>
+	<span>
+		<xsl:text> </xsl:text>
+	</span>
 </xsl:template>
 
 <xsl:template match="@style">

--- a/marklogic/src/main/ml-modules/root/judgments/xslts/judgment2.xsl
+++ b/marklogic/src/main/ml-modules/root/judgments/xslts/judgment2.xsl
@@ -88,7 +88,7 @@
 		<xsl:apply-templates />
 		<xsl:apply-templates select="attachments/attachment/doc[@name=('annex','schedule')]" />
 		<xsl:call-template name="footnotes">
-			<xsl:with-param name="footnotes">
+			<xsl:with-param name="footnotes" as="element()*">
 				<xsl:sequence select="header//authorialNote" />
 				<xsl:sequence select="judgmentBody//authorialNote" />
 				<xsl:sequence select="attachments/attachment/doc[@name=('annex','schedule')]//authorialNote" />
@@ -431,8 +431,8 @@
 </xsl:template>
 
 <xsl:template name="footnotes">
-	<xsl:param name="footnotes" select="descendant::authorialNote" />
-	<xsl:if test="$footnotes">
+	<xsl:param name="footnotes" as="element()*" select="descendant::authorialNote" />
+	<xsl:if test="exists($footnotes)">
 		<footer>
 			<hr />
 			<xsl:apply-templates select="$footnotes" mode="footnote" />


### PR DESCRIPTION
There are two tiny bug fixes here. The first removes the <hr> at the bottom of judgments, if there are no footnotes. The second ensures that there is a space within <span>s that take the place of Word tabs.