### PR TITLE
Deprecate loading data locally from S3, recommend doing an export/imp…

### DIFF
--- a/marklogic/README.md
+++ b/marklogic/README.md
@@ -52,7 +52,10 @@ examples for future data migrations.
 
 ## Local development
 
-### Loading from a backup
+The simplest way to get a set of data in your local instance of Marklogic is to do a [Bulk export](#bulk-export) from
+staging or production, then a [Bulk import](#bulk-import) to your local development environment.
+
+### Loading data from a backup on S3 (deprecated)
 
 Rather than running an import of a set of files, you can restore from a shared backup. Note that this
 bucket is currently only available to dxw developers.


### PR DESCRIPTION
…ort instead

Loading data into Marklogic from S3 is no longer the recommended method - it's
easier to do an export/import from staging or prod.