### PR TITLE
Re-enable rendering of non-websafe images

### DIFF
--- a/marklogic/src/main/ml-modules/root/judgments/xslts/judgment0.xsl
+++ b/marklogic/src/main/ml-modules/root/judgments/xslts/judgment0.xsl
@@ -335,12 +335,10 @@ body { margin: 1cm 1in }
 </xsl:template>
 
 <xsl:template match="img">
-	<xsl:if test="matches(@src, '\.gif$|\.png$|\.jpg$|\.jpeg$|\.webp$|\.svg$|\.bmp$')">
-		<img>
-			<xsl:apply-templates select="@*" />
-			<xsl:apply-templates />
-		</img>
-	</xsl:if>
+	<img>
+		<xsl:apply-templates select="@*" />
+		<xsl:apply-templates />
+	</img>
 </xsl:template>
 <xsl:template match="img/@src">
 	<xsl:attribute name="src">

--- a/marklogic/src/main/ml-modules/root/judgments/xslts/judgment2.xsl
+++ b/marklogic/src/main/ml-modules/root/judgments/xslts/judgment2.xsl
@@ -311,12 +311,10 @@
 </xsl:template>
 
 <xsl:template match="img">
-	<xsl:if test="matches(@src, '\.gif$|\.png$|\.jpg$|\.jpeg$|\.webp$|\.svg$|\.bmp$')">
-		<img>
-			<xsl:apply-templates select="@*" />
-			<xsl:apply-templates />
-		</img>
-	</xsl:if>
+	<img>
+		<xsl:apply-templates select="@*" />
+		<xsl:apply-templates />
+	</img>
 </xsl:template>
 <xsl:template match="img/@src">
 	<xsl:attribute name="src">


### PR DESCRIPTION
After discussion with the editorial team, we have decided it is more helpful
for non-websafe images to show as broken images in the HTML rengering of a
judgment, than for nothing to appear. If we show a broken image, then the
editorial team can know to send the judgment back to the clerk, and ask for
images to be supplied in an approved format.

https://trello.com/c/TLYCwwjX