### PR TITLE
Release v1.0.3

### DIFF
--- a/marklogic/CHANGELOG.md
+++ b/marklogic/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ## [Unreleased]
 
+## [Release 1.0.3]
+- Document FRBRdate discussion as an ADR
+- remove inline fonts (except Symbol)
+- remove <h2>s
+- Deprecate loading data locally from S3
+
 ## [Release 1.0.2]
 - use <b>, <i> and <u> elements
 
@@ -16,7 +22,8 @@ The format is based on [Keep a Changelog 1.0.0].
 - Initial tagged release
 - Add transformation sort order for search
 
-[Unreleased]: https://github.com/nationalarchives/ds-caselaw-public-access-service/compare/v1.0.2...HEAD
+[Unreleased]: https://github.com/nationalarchives/ds-caselaw-public-access-service/compare/v1.0.3...HEAD
+[Release 1.0.3]: https://github.com/nationalarchives/ds-caselaw-public-access-service/compare/v1.0.2...v1.0.3
 [Release 1.0.2]: https://github.com/nationalarchives/ds-caselaw-public-access-service/compare/v1.0.1...v1.0.2
 [Release 1.0.1]: https://github.com/nationalarchives/ds-caselaw-public-access-service/compare/v1.0.0...v1.0.1
 - [keep a changelog 1.0.0]: https://keepachangelog.com/en/1.0.0/


### PR DESCRIPTION
- Document FRBRdate discussion as an ADR
- remove inline fonts (except Symbol)
- remove `<h2>`s
- Deprecate loading data locally from S3