### PR TITLE
Add a new privilege and role allowing users to view unpublished documents

### DIFF
--- a/marklogic/src/main/ml-config/security/roles/2-caselaw-reader-role.json
+++ b/marklogic/src/main/ml-config/security/roles/2-caselaw-reader-role.json
@@ -1,5 +1,5 @@
 {
   "role-name" : "caselaw-reader",
-  "description" : "Can view documents, but not edit",
+  "description" : "Can view documents, not including unpublished documents, but not edit",
   "role" : [ "rest-reader", "caselaw-nobody" ]
 }

--- a/marklogic/src/main/ml-config/security/roles/6-caselaw-unpublished-reader-role.json
+++ b/marklogic/src/main/ml-config/security/roles/6-caselaw-unpublished-reader-role.json
@@ -1,0 +1,12 @@
+{
+  "role-name" : "caselaw-unpublished-reader",
+  "description" : "Can view documents, including unpublished documents, but not edit",
+  "role" : [ "rest-reader", "caselaw-nobody" ],
+  "privilege": [
+    {
+      "privilege-name": "can-view-unpublished-documents",
+      "kind": "execute",
+      "action": "https://caselaw.nationalarchives.gov.uk/custom/privileges/can-view-unpublished-documents"
+    }
+  ]
+}


### PR DESCRIPTION
Trello: https://trello.com/c/o3Wbto2N/263-implement-preview-permissions

There is a requirement with the privileged API to grant some users the ability
to view unpublished judgments, depending on their user account.

The thought behind this is to add a new `caselaw-unpublished-reader` role
which is similar to the existing `caselaw-reader` role, but indicates the users
with this role can view unpublished documents.

Further down the line, we can add an endpoint to `ds-caselaw-custom-api-client`
where we can pass in a user name, and check to see if they have this role/
privilege.

<img width="1035" alt="Screenshot 2022-08-18 at 12 00 49" src="https://user-images.githubusercontent.com/1089521/185379666-011fc3b2-d9d4-4436-9f72-accab9c9e6fe.png">
<img width="916" alt="Screenshot 2022-08-18 at 12 00 32" src="https://user-images.githubusercontent.com/1089521/185379671-e114921c-6210-47e6-81d9-ae5b87fb441a.png">
