### PR TITLE
Create failover replicas for the caselaw-content databases

### DIFF
--- a/marklogic/gradle.properties
+++ b/marklogic/gradle.properties
@@ -3,7 +3,8 @@
 mlAppName=caselaw
 mlRestPort=8011
 mlRestAuthentication=basic
-
+# create replicas of caselaw-content database
+mlDatabaseNamesAndReplicaCounts=caselaw-content,2,caselaw-modules,2,caselaw-triggers,2,Security,2
 # Controls which additional properties file is used by the Gradle properties plugin - https://github.com/stevesaliman/gradle-properties-plugin
 # Defaults to 'local' when the property doesn't exist, and gradle-local.properties should be ignored by version control
 environmentName=development


### PR DESCRIPTION
By default a marklogic cluster does not deal with losing forests from a
database very well. If it cant find a forest due to a machine being missing it
will stop responding to queries.

This sets and creates failover replicas of the main forests so that losing a
the forests on a machine should not impact the clusters health to much.

https://github.com/marklogic-community/ml-gradle/wiki/Creating-forests#replica-forest-creation