### PR TITLE
Use unfiltered search results

### DIFF
--- a/marklogic/src/main/ml-modules/root/judgments/search/search.xqy
+++ b/marklogic/src/main/ml-modules/root/judgments/search/search.xqy
@@ -119,6 +119,7 @@ else
 
 let $search-options := <options xmlns="http://marklogic.com/appservices/search">
     <fragment-scope>{ $scope }</fragment-scope>
+    <search-option>unfiltered</search-option>
     { $sort-order }
     <extract-document-data xmlns:akn="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
         <extract-path>//akn:FRBRWork/akn:FRBRdate</extract-path>


### PR DESCRIPTION
Using unfiltered search results speeds up access of high page numbered search terms, i.e.:
https://staging.caselaw.nationalarchives.gov.uk/judgments/advanced_search?page=5000 loads very quickly now.

There were problems with this apparently not working, but they were due to my gradle config pointing at the old staging instance.

This is effectively already on staging due to us putting the data there.