### PR TITLE
Add KB to Neutral Citation regex in helper.xqy

### DIFF
--- a/marklogic/src/main/ml-modules/root/judgments/search/helper.xqy
+++ b/marklogic/src/main/ml-modules/root/judgments/search/helper.xqy
@@ -108,12 +108,12 @@ declare private variable $neutral-citation-patterns as xs:string+ := (
         '(^| )EWCA (Civ|Crim) \d+( |$)',
         '(^| )EWCA (Civ|Crim)( |$)',
         '(^| )(Civ|Crim) \d+( |$)',
-    '(^| )\[?\d{4}\]? EWHC \d+ \(?(Admin|Admlty|Ch|Comm|Costs|Fam|IPEC|Pat|QB|TCC)\)?( |$)',
+    '(^| )\[?\d{4}\]? EWHC \d+ \(?(Admin|Admlty|Ch|Comm|Costs|Fam|IPEC|Pat|QB|KB|TCC)\)?( |$)',
         '(^| )\[?\d{4}\]? EWHC \d+( |$)',
         '(^| )\[?\d{4}\]? EWHC( |$)',
-        '(^| )EWHC \d+ \(?(Admin|Admlty|Ch|Comm|Costs|Fam|IPEC|Pat|QB|TCC)\)?( |$)',
+        '(^| )EWHC \d+ \(?(Admin|Admlty|Ch|Comm|Costs|Fam|IPEC|Pat|QB|KB|TCC)\)?( |$)',
         '(^| )EWHC \d+( |$)',
-        (: '(^| )\d+ \(?(Admin|Admlty|Ch|Comm|Costs|Fam|IPEC|Pat|QB|TCC)\)?( |$)', :)
+        (: '(^| )\d+ \(?(Admin|Admlty|Ch|Comm|Costs|Fam|IPEC|Pat|QB|KB|TCC)\)?( |$)', :)
     '(^| )\[?\d{4}\]? (EWFC|EWCOP) \d+( |$)',
         '(^| )\[?\d{4}\]? (EWFC|EWCOP)( |$)',
         '(^| )(EWFC|EWCOP) \d+( |$)',


### PR DESCRIPTION
I don't quite know what'll break without this, but I'm fairly sure it'll be subtle and annoying and we'll never know where to look to fix it.

Added immediately after QB rather than alphabetical because they're the same court.

Also added to the comment for consistency's sake -- perhaps that comment should just be removed.