### PR TITLE
add paragraph ids

### DIFF
--- a/marklogic/src/main/ml-modules/root/judgments/xslts/accessible-html.xsl
+++ b/marklogic/src/main/ml-modules/root/judgments/xslts/accessible-html.xsl
@@ -157,6 +157,7 @@
 
 <xsl:template match="paragraph">
 	<section class="judgment-body__section">
+		<xsl:apply-templates select="@eId" />
 		<span class="judgment-body__number">
 			<xsl:apply-templates select="num/node()" />
 		</span>
@@ -164,6 +165,12 @@
 			<xsl:apply-templates select="* except num" />
 		</div>
 	</section>
+</xsl:template>
+
+<xsl:template match="paragraph/@eId">
+	<xsl:attribute name="id">
+		<xsl:sequence select="." />
+	</xsl:attribute>
 </xsl:template>
 
 <xsl:template match="subparagraph">

--- a/marklogic/src/main/ml-modules/root/judgments/xslts/as-handed-down.xsl
+++ b/marklogic/src/main/ml-modules/root/judgments/xslts/as-handed-down.xsl
@@ -246,7 +246,7 @@ body { margin: 1cm 1in }
 	</xsl:choose>
 </xsl:template>
 
-<xsl:template match="level | paragraph">
+<xsl:template match="level | paragraph | subparagraph">
 	<section>
 		<xsl:call-template name="class" />
 		<xsl:apply-templates select="@* except @class" />
@@ -436,6 +436,12 @@ body { margin: 1cm 1in }
 	<span class="tab">
 		<xsl:text> </xsl:text>
 	</span>
+</xsl:template>
+
+<xsl:template match="@eId">
+	<xsl:attribute name="id">
+		<xsl:sequence select="." />
+	</xsl:attribute>
 </xsl:template>
 
 <xsl:template match="@class | @style | @src | @href | @title">


### PR DESCRIPTION
These changes simply copy the value of the @eId attribute on paragraphs in the XML into the @id attribute of the corresponding HTML structure.