### PR TITLE
Update Marklogic user roles

### DIFF
--- a/marklogic/src/main/ml-config/security/roles/2-caselaw-reader-role.json
+++ b/marklogic/src/main/ml-config/security/roles/2-caselaw-reader-role.json
@@ -1,5 +1,5 @@
 {
   "role-name" : "caselaw-reader",
   "description" : "Can view documents, not including unpublished documents, but not edit",
-  "role" : [ "rest-reader", "caselaw-nobody", "security" ]
+  "role" : [ "rest-reader", "caselaw-nobody", "security", "dls-user", "dls-internal" ]
 }

--- a/marklogic/src/main/ml-config/security/roles/2-caselaw-reader-role.json
+++ b/marklogic/src/main/ml-config/security/roles/2-caselaw-reader-role.json
@@ -1,5 +1,5 @@
 {
   "role-name" : "caselaw-reader",
   "description" : "Can view documents, not including unpublished documents, but not edit",
-  "role" : [ "rest-reader", "caselaw-nobody" ]
+  "role" : [ "rest-reader", "caselaw-nobody", "security" ]
 }

--- a/marklogic/src/main/ml-config/security/roles/3-caselaw-writer-role.json
+++ b/marklogic/src/main/ml-config/security/roles/3-caselaw-writer-role.json
@@ -1,7 +1,7 @@
 {
   "role-name" : "caselaw-writer",
   "description" : "Can read and write all documents, including unpublished",
-  "role" : [ "rest-writer", "caselaw-unpublished-reader" ],
+  "role" : [ "rest-writer", "caselaw-reader", "caselaw-unpublished-reader" ],
   "privilege" : [ {
     "privilege-name" : "any-uri",
     "action" : "http://marklogic.com/xdmp/privileges/any-uri",

--- a/marklogic/src/main/ml-config/security/roles/5-caselaw-admin-role.json
+++ b/marklogic/src/main/ml-config/security/roles/5-caselaw-admin-role.json
@@ -1,7 +1,7 @@
 {
   "role-name" : "caselaw-admin",
   "description" : "Non-admin administrator",
-  "role" : [ "rest-admin", "manage-admin", "caselaw-writer" ],
+  "role" : [ "rest-admin", "manage-admin", "caselaw-writer", "caselaw-unpublished-reader" ],
   "privilege" : [ {
     "privilege-name" : "any-uri",
     "action" : "http://marklogic.com/xdmp/privileges/any-uri",

--- a/marklogic/src/main/ml-config/security/roles/6-caselaw-unpublished-reader-role.json
+++ b/marklogic/src/main/ml-config/security/roles/6-caselaw-unpublished-reader-role.json
@@ -1,7 +1,7 @@
 {
   "role-name" : "caselaw-unpublished-reader",
   "description" : "Can view documents, including unpublished documents, but not edit",
-  "role" : [ "rest-reader", "caselaw-nobody" ],
+  "role" : [ "caselaw-reader" ],
   "privilege": [
     {
       "privilege-name": "can-view-unpublished-documents",

--- a/marklogic/src/main/ml-config/security/roles/7-caselaw-priv-api-writer-role.json
+++ b/marklogic/src/main/ml-config/security/roles/7-caselaw-priv-api-writer-role.json
@@ -1,0 +1,5 @@
+{
+  "role-name" : "priv-api-writer",
+  "description" : "Can view documents, including unpublished documents, and edit",
+  "role" : [ "caselaw-writer", "caselaw-unpublished-reader" ]
+}

--- a/marklogic/src/main/ml-config/security/users/caselaw-editor-ui.json
+++ b/marklogic/src/main/ml-config/security/users/caselaw-editor-ui.json
@@ -1,5 +1,5 @@
 {
   "user-name" : "caselaw-editor-ui",
   "description" : "The Editor UI reader & writer",
-  "role" : [ "dls-admin", "rest-writer" ]
+  "role" : [ "dls-admin", "rest-writer", "caselaw-unpublished-reader", "caselaw-writer" ]
 }

--- a/marklogic/src/main/ml-config/security/users/caselaw-public-ui.json
+++ b/marklogic/src/main/ml-config/security/users/caselaw-public-ui.json
@@ -1,5 +1,5 @@
 {
   "user-name" : "caselaw-public-ui",
   "description" : "The Public UI reader",
-  "role" : [ "rest-reader", "rest-extension-user" ]
+  "role" : [ "rest-reader", "rest-extension-user", "caselaw-reader" ]
 }


### PR DESCRIPTION
Please see commit messages!

This PR tidies up the Marklogic roles in our Gradle config. These had become out of sync with what was stored in Marklogic.

It also addresses an issue we had with the caselaw user accounts not being able to transform documents or use the search function (because the `eval` and `invoke` operations in Marklogic need the `security` role); or search within document properties (because the documents are ingested using the `dls-internal` role and users need this role to view document properties).

After this PR is merged, we should be able to move all app users onto custom caselaw roles.