### PR TITLE
Add uk:court, uk:hash and akn:FRBRManifestation/akn:FRBRdate to the search result

### DIFF
--- a/marklogic/src/main/ml-modules/root/judgments/search/search-v2.xqy
+++ b/marklogic/src/main/ml-modules/root/judgments/search/search-v2.xqy
@@ -135,6 +135,9 @@ let $search-options := <options xmlns="http://marklogic.com/appservices/search">
         <extract-path>//akn:FRBRWork/akn:FRBRname</extract-path>
         <extract-path>//uk:cite</extract-path>
         <extract-path>//akn:neutralCitation</extract-path>
+        <extract-path>//uk:court</extract-path>
+        <extract-path>//uk:hash</extract-path>
+        <extract-path>//akn:FRBRManifestation/akn:FRBRdate</extract-path>
     </extract-document-data>
     { $transform-results }
 </options>

--- a/marklogic/src/main/ml-modules/root/judgments/search/search.xqy
+++ b/marklogic/src/main/ml-modules/root/judgments/search/search.xqy
@@ -131,6 +131,9 @@ let $search-options := <options xmlns="http://marklogic.com/appservices/search">
         <extract-path>//akn:FRBRWork/akn:FRBRname</extract-path>
         <extract-path>//uk:cite</extract-path>
         <extract-path>//akn:neutralCitation</extract-path>
+        <extract-path>//uk:court</extract-path>
+        <extract-path>//uk:hash</extract-path>
+        <extract-path>//akn:FRBRManifestation/akn:FRBRdate</extract-path>
     </extract-document-data>
     { $transform-results }
 </options>


### PR DESCRIPTION
Trello: https://trello.com/c/wBZUsMuz

I have added this to `search.qxy` even though this XQuery is deprecated, as without it the search results would not be correct.