### PR TITLE
Add the `xdbc-eval` and `xdbc-invoke` privileges to caselaw-reader

### DIFF
--- a/marklogic/src/main/ml-config/security/roles/2-caselaw-reader-role.json
+++ b/marklogic/src/main/ml-config/security/roles/2-caselaw-reader-role.json
@@ -1,5 +1,14 @@
 {
   "role-name" : "caselaw-reader",
   "description" : "Can view documents, not including unpublished documents, but not edit",
-  "role" : [ "rest-reader", "caselaw-nobody", "security", "dls-user", "dls-internal" ]
+  "role" : [ "rest-reader", "caselaw-nobody", "security", "dls-user", "dls-internal" ],
+  "privilege" : [ {
+    "privilege-name" : "xdbc:eval",
+    "action" : "http://marklogic.com/xdmp/privileges/xdbc-eval",
+    "kind" : "execute"
+  }, {
+    "privilege-name" : "xdbc:invoke",
+    "action" : "http://marklogic.com/xdmp/privileges/xdbc-invoke",
+    "kind" : "execute"
+  } ]
 }


### PR DESCRIPTION
These two privileges are needed to cal lthe `eval` and `invoke` endpoints on the Marklogic REST API.

These privileges had been set via the Marklogic admin console on staging, but not copied over to the Gradle config.

Todo: Find a better way to make sure any changes made in the consoles are recorded in the Gradle config!