### PR TITLE
remove first column and add @class to certain header tables

### DIFF
--- a/marklogic/src/main/ml-modules/root/judgments/xslts/accessible-html.xsl
+++ b/marklogic/src/main/ml-modules/root/judgments/xslts/accessible-html.xsl
@@ -450,6 +450,44 @@
 	</xsl:element>
 </xsl:template>
 
+<!-- header tables -->
+
+<xsl:template match="header//table">
+	<xsl:choose>
+		<xsl:when test="every $row in * satisfies uk:can-remove-first-column($row)">
+			<xsl:apply-templates select="." mode="remove-first-column" />
+		</xsl:when>
+		<xsl:otherwise>
+			<xsl:next-match />
+		</xsl:otherwise>
+	</xsl:choose>
+</xsl:template>
+
+<xsl:function name="uk:can-remove-first-column" as="xs:boolean">
+	<xsl:param name="row" as="element()" />
+	<xsl:sequence select="count($row/*) = 3 and uk:cell-is-empty($row/*[1])" />
+</xsl:function>
+
+<xsl:function name="uk:cell-is-empty" as="xs:boolean">
+	<xsl:param name="cell" as="element()" />
+	<xsl:sequence select="empty($cell/@colspan) and empty($cell/@rowspan) and not(normalize-space($cell))" />
+</xsl:function>
+
+<xsl:template match="table" mode="remove-first-column">
+	<table class="pr_two_column">
+		<tbody>
+			<xsl:apply-templates mode="remove-first-column" />
+		</tbody>
+	</table>
+</xsl:template>
+
+<xsl:template match="tr" mode="remove-first-column">
+	<tr>
+		<xsl:copy-of select="@*" />
+		<xsl:apply-templates select="*[position() gt 1]" />
+	</tr>
+</xsl:template>
+
 
 <!-- links -->
 


### PR DESCRIPTION
This change removes the empty first column, and adds the "pr_two_column" class attribute, to certain tables in the header.