### PR TITLE
avoid ambiguous rule match

### DIFF
--- a/marklogic/src/main/ml-modules/root/judgments/xslts/accessible-html.xsl
+++ b/marklogic/src/main/ml-modules/root/judgments/xslts/accessible-html.xsl
@@ -256,7 +256,7 @@
 	</xsl:choose>
 </xsl:function>
 
-<xsl:template match="header//p">
+<xsl:template match="header//p[not(parent::blockContainer)]">
 	<xsl:choose>
 		<xsl:when test="empty(preceding-sibling::*) and exists(child::img)">
 			<div class="judgment-header__logo">


### PR DESCRIPTION
This small fix avoids the ambiguity for templates matching numbered paragraphs in the header. More specifically, between `<xsl:template match="header//p">` and the `<xsl:template match="blockContainer/p[1]">`.