### PR TITLE
Table Header Rows

### DIFF
--- a/marklogic/src/main/ml-modules/root/judgments/xslts/accessible-html.xsl
+++ b/marklogic/src/main/ml-modules/root/judgments/xslts/accessible-html.xsl
@@ -476,13 +476,19 @@
 
 <xsl:template match="table">
 	<table>
+		<xsl:variable name="header-rows" as="element()*" select="*[child::th]" />
+		<xsl:if test="exists($header-rows)">
+			<thead>
+				<xsl:apply-templates select="$header-rows" />
+			</thead>
+		</xsl:if>
 		<tbody>
-			<xsl:apply-templates />
+			<xsl:apply-templates select="* except $header-rows" />
 		</tbody>
 	</table>
 </xsl:template>
 
-<xsl:template match="tr | td">
+<xsl:template match="tr | th | td">
 	<xsl:element name="{ local-name() }">
 		<xsl:copy-of select="@*" />
 		<xsl:apply-templates />

--- a/marklogic/src/main/ml-modules/root/judgments/xslts/as-handed-down.xsl
+++ b/marklogic/src/main/ml-modules/root/judgments/xslts/as-handed-down.xsl
@@ -380,13 +380,19 @@ body { margin: 1cm 1in }
 				</xsl:for-each>
 			</colgroup>
 		</xsl:if>
+		<xsl:variable name="header-rows" as="element()*" select="*[child::th]" />
+		<xsl:if test="exists($header-rows)">
+			<thead>
+				<xsl:apply-templates select="$header-rows" />
+			</thead>
+		</xsl:if>
 		<tbody>
-			<xsl:apply-templates />
+			<xsl:apply-templates select="* except $header-rows" />
 		</tbody>
 	</table>
 </xsl:template>
 
-<xsl:template match="tr | td">
+<xsl:template match="tr | th| td">
 	<xsl:element name="{ local-name() }">
 		<xsl:copy-of select="@*" />
 		<xsl:apply-templates />


### PR DESCRIPTION
The parser does not yet support table header rows, but it soon will. When it does, this change is necessary so they carry through properly to the HTML.

Until the parser change is released, these changes to the HTML transform will have no effect.