### PR TITLE
Fix regex used for renovate-config-validator in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
     hooks:
       - id: renovate-config-validator
         args: [--strict]
-        files: default.json|renovate.json
+        files: (^|/)(default|renovate)\\.json$
 
   - repo: https://github.com/woodruffw/zizmor-pre-commit
     rev: v1.23.1


### PR DESCRIPTION
This improved regex limits checks to files in the root, and properly escapes the `.` in the filename.