### PR TITLE
Add the :pinDependencies Renovate preset

### DIFF
--- a/default.json
+++ b/default.json
@@ -8,7 +8,8 @@
     ":automergeRequireAllStatusChecks",
     ":automergeTesters",
     ":maintainLockFilesWeekly",
-    ":enablePreCommit"
+    ":enablePreCommit",
+    ":pinDependencies"
   ],
   "timezone": "Europe/London",
   "platformAutomerge": true,


### PR DESCRIPTION
This [preset](https://docs.renovatebot.com/presets-default/#pindependencies) encourages Renovate to pin dependencies to exact versions, rather than allowing looser matches.