### PR TITLE
Remove optic, add openapi-spec-validator

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,15 +27,10 @@ repos:
       - id: prettier
         types_or: [yaml, json, xml, markdown, scss, javascript]
 
-  - repo: local
+  - repo: https://github.com/python-openapi/openapi-spec-validator
+    rev: 0.8.4
     hooks:
-      - id: optic-diff
-        name: Optic
-        entry: bash -c 'set -e; for x in "$@"; do optic diff "$x"; done' --
-        language: node
-        require_serial: true
-        additional_dependencies:
-          - "@useoptic/optic@1.0.9"
+      - id: openapi-spec-validator
         files: ^doc/openapi/.*\.yml
 
   - repo: https://github.com/renovatebot/pre-commit-hooks


### PR DESCRIPTION
Verified that it falls over if the OpenAPI is bad:

```
doc/openapi/privileged_api.yml: Validation Error: 'name' is a required property

Failed validating 'required' in schema['properties']['tags']['items']:
    {'type': 'object',
     'required': ['name'],
     'properties': {'name': {'type': 'string'},
                    'description': {'type': 'string'},
                    'externalDocs': {'$ref': '#/definitions/ExternalDocumentation'}},
     'patternProperties': {'^x-': {}},
     'additionalProperties': False}

On instance['tags'][0]:
    {'namfjicdjcie': 'Status',
     'description': 'Verify the operational state of the API'}
```