### PR TITLE
Renovate config: widen python

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>nationalarchives/ds-find-caselaw-docs"]
+  "extends": ["github>nationalarchives/ds-find-caselaw-docs"],
+  "packageRules": [
+    {
+      "matchPackageNames": ["python"],
+      "rangeStrategy": "widen"
+    }
+  ]
 }


### PR DESCRIPTION
Whenever a python version is specified we typically mean "at least this version". Python is also not managed by poetry so Poetry doesn't get to pick the version to install.

See also https://github.com/nationalarchives/ds-caselaw-utils/pull/675
