### PR TITLE
Improve Renovate configuration with Playwright grouping and Python fix

### DIFF
--- a/default.json
+++ b/default.json
@@ -56,6 +56,11 @@
       "matchPackageNames": ["stylelint", "stylelint-config-standard-scss"],
       "groupName": "Stylelint and standard SCSS config",
       "groupSlug": "stylelint"
+    },
+    {
+      "matchPackageNames": ["mcr.microsoft.com/playwright", "playwright"],
+      "groupName": "Playwright",
+      "groupSlug": "playwright"
     }
   ],
   "labels": ["dependencies"],

--- a/default.json
+++ b/default.json
@@ -61,6 +61,10 @@
       "matchPackageNames": ["mcr.microsoft.com/playwright", "playwright"],
       "groupName": "Playwright",
       "groupSlug": "playwright"
+    },
+    {
+      "matchPackageNames": ["python"],
+      "rangeStrategy": "widen"
     }
   ],
   "labels": ["dependencies"],

--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>nationalarchives/ds-find-caselaw-docs"],
-  "packageRules": [
-    {
-      "matchPackageNames": ["python"],
-      "rangeStrategy": "widen"
-    }
-  ]
+  "extends": ["github>nationalarchives/ds-find-caselaw-docs"]
 }


### PR DESCRIPTION
This PR improves our global Renovate behaviour by:

- Grouping together Playwright Docker and Python package updates
- Moving our Python versioning strategy to the global configuration, rather than repo-specific