### PR TITLE
Make sure playwright grouping rules include Docker

### DIFF
--- a/default.json
+++ b/default.json
@@ -47,7 +47,12 @@
       "groupSlug": "stylelint-group"
     },
     {
-      "matchPackageNames": ["/playwright/"],
+      "matchManagers": ["pip_requirements", "dockerfile"],
+      "matchPackageNames": [
+        "playwright",
+        "pytest-playwright",
+        "mcr.microsoft.com/playwright/python"
+      ],
       "groupName": "Playwright",
       "groupSlug": "playwright-group"
     },


### PR DESCRIPTION
Our current grouping rules aren't properly picking up Docker image updates, so we're still getting failing PRs for Playwright.

This PR attempts to improve our package grouping to address this.