### PR TITLE
Make release timestamp optional for Playwright group

### DIFF
--- a/default.json
+++ b/default.json
@@ -53,6 +53,7 @@
         "pytest-playwright",
         "mcr.microsoft.com/playwright/python"
       ],
+      "minimumReleaseAgeBehaviour": "timestamp-optional",
       "groupName": "Playwright",
       "groupSlug": "playwright-group"
     },


### PR DESCRIPTION
Because Microsoft Container Registry doesn't include timestamp information in its metadata for the Playwright Docker tag, Renovate is unable to determine how old the update is. This means the update is perpetually marked as pending, since the age cannot be verified.
    
Set the `minimumReleaseAgeBehaviour` to `timestamp-optional` for the Playwright group, so a missing timestamp is treated as a stable release rather than an unstable one. Packages with timestamps will still need to meet stability requirements to merge.