### PR TITLE
[FCLC-2006] List of types of metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 generated
 .DS_Store
 node_modules/
+*.pyc

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,13 @@ repos:
         language: python
         pass_filenames: false
 
+      - id: build-document-metadata-table
+        name: Build document metadata table
+        entry: python scripts/build_document_metadata_table
+        language: python
+        additional_dependencies: [pyyaml]
+        pass_filenames: false
+
   - repo: https://github.com/renovatebot/pre-commit-hooks
     rev: 43.216.1
     hooks:

--- a/doc/document-metadata.md
+++ b/doc/document-metadata.md
@@ -1,0 +1,180 @@
+# Document metadata
+
+This document lists all the types of metadata which can be associated with a document, if that metadata exists at the level of document, submission or version, how to access that metadata, how that metadata is sourced, and if that metadata should be considered editable.
+
+<!-- Begin document metadata table -->
+<!-- Generated from scripts/build_document_metadata_table using scripts/document-metadata.yml. Do not edit manually. -->
+
+## Summary
+
+| Name                                              | Level                                      | Sourced from                                                | Editable | Multiple |
+| ------------------------------------------------- | ------------------------------------------ | ----------------------------------------------------------- | -------- | -------- |
+| [Case number](#metadata-casenumber)               | Document body                              | Parser (Document body)<br>Metadata file                     | No       | No       |
+| [Categories](#metadata-categories)                | Document body                              | Parser (Document body)<br>Metadata file                     | No       | No       |
+| [Court](#metadata-court)                          | Document body                              | Parser (Document body)<br>Metadata file<br>EUI<br>Stub form | Yes      | No       |
+| [Identifiers](#metadata-identifiers)              | Document properties                        | Ingester<br>EUI                                             | Yes      | Yes      |
+| [Judges](#metadata-judges)                        | Document body                              | Parser (Document body)<br>Metadata file<br>Stub form        | No       | Yes      |
+| [Judgment date](#metadata-date)                   | Document body                              | Parser (Document body)<br>Metadata file<br>EUI<br>Stub form | Yes      | No       |
+| [Jurisdiction](#metadata-jurisdiction)            | Document body                              | Parser (Document body)                                      | No       | No       |
+| [Name](#metadata-name)                            | Document body                              | Parser (Document body)<br>Metadata file<br>EUI<br>Stub form | Yes      | No       |
+| [NCN](#metadata-cite)                             | Document properties, document body         | Parser (Document body)<br>Metadata file<br>EUI<br>Stub form | Yes      | No       |
+| [Parties](#metadata-parties)                      | Document body                              | Parser (Document body)<br>Metadata file                     | No       | Yes      |
+| [Source email](#metadata-sourceemail)             | Document properties (should be Submission) | Parser (TDR metadata)                                       | No       | No       |
+| [Source name](#metadata-sourcename)               | Document properties (should be Submission) | Parser (TDR metadata)                                       | No       | No       |
+| [TDR reference](#metadata-consignmentreference)   | Document properties (should be Submission) | Parser (TDR metadata)                                       | No       | No       |
+| [URI](#metadata-uri)                              | Document object (inherent property)        | System                                                      | No       | No       |
+| [Version annotation](#metadata-versionannotation) | Version                                    | Ingester<br>Enrichment                                      | No       | No       |
+
+## Details
+
+<a id="metadata-casenumber"></a>
+
+### Case number
+
+The case number for the case this document relates to.
+
+| Level         | Sourced from                            | Editable | Multiple | Access via                  |
+| ------------- | --------------------------------------- | -------- | -------- | --------------------------- |
+| Document body | Parser (Document body)<br>Metadata file | No       | No       | `Document.body.case_number` |
+
+<a id="metadata-categories"></a>
+
+### Categories
+
+Categories under which this document falls
+
+| Level         | Sourced from                            | Editable | Multiple | Access via                 |
+| ------------- | --------------------------------------- | -------- | -------- | -------------------------- |
+| Document body | Parser (Document body)<br>Metadata file | No       | No       | `Document.body.categories` |
+
+<a id="metadata-court"></a>
+
+### Court
+
+The court which published this document. "Court" here means "any body capable of issuing a legally binding decision".
+
+| Level         | Sourced from                                                | Editable | Multiple | Access via            |
+| ------------- | ----------------------------------------------------------- | -------- | -------- | --------------------- |
+| Document body | Parser (Document body)<br>Metadata file<br>EUI<br>Stub form | Yes      | No       | `Document.body.court` |
+
+<a id="metadata-identifiers"></a>
+
+### Identifiers
+
+Identifiers for a document (NCN, FCLID etc) stored within the structured identifier system.
+
+| Level               | Sourced from    | Editable | Multiple | Access via             |
+| ------------------- | --------------- | -------- | -------- | ---------------------- |
+| Document properties | Ingester<br>EUI | Yes      | Yes      | `Document.identifiers` |
+
+<a id="metadata-judges"></a>
+
+### Judges
+
+A list of the names of the judges (or equivalent for the body) involved in any particular case.
+
+| Level         | Sourced from                                         | Editable | Multiple |
+| ------------- | ---------------------------------------------------- | -------- | -------- |
+| Document body | Parser (Document body)<br>Metadata file<br>Stub form | No       | Yes      |
+
+<a id="metadata-date"></a>
+
+### Judgment date
+
+The date the document was published, usually the date a decision was handed down.
+
+| Level         | Sourced from                                                | Editable | Multiple | Access via                              |
+| ------------- | ----------------------------------------------------------- | -------- | -------- | --------------------------------------- |
+| Document body | Parser (Document body)<br>Metadata file<br>EUI<br>Stub form | Yes      | No       | `Document.body.document_date_as_string` |
+
+<a id="metadata-jurisdiction"></a>
+
+### Jurisdiction
+
+The jurisdiction of the court which this decision was made under
+
+| Level         | Sourced from           | Editable | Multiple | Access via                   |
+| ------------- | ---------------------- | -------- | -------- | ---------------------------- |
+| Document body | Parser (Document body) | No       | No       | `Document.body.jurisdiction` |
+
+<a id="metadata-name"></a>
+
+### Name
+
+The title of the document as most commonly used by humans. This _may_ vary from the exact title in the document text, for example by standardising casing.
+
+| Level         | Sourced from                                                | Editable | Multiple | Access via           |
+| ------------- | ----------------------------------------------------------- | -------- | -------- | -------------------- |
+| Document body | Parser (Document body)<br>Metadata file<br>EUI<br>Stub form | Yes      | No       | `Document.body.name` |
+
+<a id="metadata-cite"></a>
+
+### NCN
+
+Where present, this document's Neutral Citation Number. This is a special case of identifier, which we actually want to deprecate.
+
+| Level                              | Sourced from                                                | Editable | Multiple | Access via                                              |
+| ---------------------------------- | ----------------------------------------------------------- | -------- | -------- | ------------------------------------------------------- |
+| Document properties, document body | Parser (Document body)<br>Metadata file<br>EUI<br>Stub form | Yes      | No       | `Document.identifiers.preferred(NeutralCitationNumber)` |
+
+<a id="metadata-parties"></a>
+
+### Parties
+
+A list of the names of the parties involved in any particular case. This does _not_ include structured data on the nature of the party (eg defendant/appellant).
+
+| Level         | Sourced from                            | Editable | Multiple |
+| ------------- | --------------------------------------- | -------- | -------- |
+| Document body | Parser (Document body)<br>Metadata file | No       | Yes      |
+
+<a id="metadata-sourceemail"></a>
+
+### Source email
+
+The email address of the person who submitted the document.
+
+| Level                                      | Sourced from          | Editable | Multiple | Access via              |
+| ------------------------------------------ | --------------------- | -------- | -------- | ----------------------- |
+| Document properties (should be Submission) | Parser (TDR metadata) | No       | No       | `Document.source_email` |
+
+<a id="metadata-sourcename"></a>
+
+### Source name
+
+The name of the person who submitted the document.
+
+| Level                                      | Sourced from          | Editable | Multiple | Access via             |
+| ------------------------------------------ | --------------------- | -------- | -------- | ---------------------- |
+| Document properties (should be Submission) | Parser (TDR metadata) | No       | No       | `Document.source_name` |
+
+<a id="metadata-consignmentreference"></a>
+
+### TDR reference
+
+The TDR reference of the submission.
+
+| Level                                      | Sourced from          | Editable | Multiple | Access via                       |
+| ------------------------------------------ | --------------------- | -------- | -------- | -------------------------------- |
+| Document properties (should be Submission) | Parser (TDR metadata) | No       | No       | `Document.consignment_reference` |
+
+<a id="metadata-uri"></a>
+
+### URI
+
+The unique identifier for the document.
+
+| Level                               | Sourced from | Editable | Multiple | Access via     |
+| ----------------------------------- | ------------ | -------- | -------- | -------------- |
+| Document object (inherent property) | System       | No       | No       | `Document.uri` |
+
+<a id="metadata-versionannotation"></a>
+
+### Version annotation
+
+A (hopefully) structured JSON blob describing how and why a new version of a document came into being.
+
+| Level   | Sourced from           | Editable | Multiple | Access via            |
+| ------- | ---------------------- | -------- | -------- | --------------------- |
+| Version | Ingester<br>Enrichment | No       | No       | `Document.annotation` |
+
+<!-- End document metadata table -->

--- a/scripts/build_document_metadata_table
+++ b/scripts/build_document_metadata_table
@@ -1,0 +1,203 @@
+#!/usr/bin/env python
+
+import re
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+from markdown_table_renderer import render_markdown_table
+
+try:
+    import yaml
+except ImportError as exc:  # pragma: no cover
+    msg = "PyYAML is required to run this script. Install with: pip install pyyaml"
+    raise SystemExit(msg) from exc
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+METADATA_PATH = SCRIPT_DIR / "document-metadata.yml"
+DOC_PATH = SCRIPT_DIR.parent / "doc" / "document-metadata.md"
+
+BEGIN_MARKER = "<!-- Begin document metadata table -->"
+END_MARKER = "<!-- End document metadata table -->"
+GENERATED_NOTE = (
+    "<!-- Generated from scripts/build_document_metadata_table using scripts/document-metadata.yml. "
+    "Do not edit manually. -->"
+)
+
+
+def format_header(key: str) -> str:
+    if key == "sources":
+        return "Sourced from"
+    if key == "access":
+        return "Access via"
+    return key.replace("_", " ").replace("-", " ").title()
+
+
+def markdown_escape(value: object) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return "Yes" if value else "No"
+    if isinstance(value, Sequence) and not isinstance(value, str):
+        rendered_items = [markdown_escape(item) for item in value]
+        return "<br>".join(rendered_items)
+    text = str(value)
+    return text.replace("|", "\\|").replace("\n", "<br>")
+
+
+def render_detail_value(key: str, value: object) -> str:
+    if key != "access":
+        return markdown_escape(value)
+
+    if isinstance(value, Sequence) and not isinstance(value, str):
+        return "<br>".join(f"`{markdown_escape(item)}`" for item in value)
+
+    return f"`{markdown_escape(value)}`"
+
+
+def slugify(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9\s-]", "", value.lower())
+    slug = re.sub(r"\s+", "-", slug).strip("-")
+    return slug or "item"
+
+
+def normalise_rows(raw_data: object) -> list[dict[str, object]]:
+    if raw_data is None:
+        return []
+
+    if isinstance(raw_data, Mapping):
+        rows: list[dict[str, object]] = []
+        for metadata_key, metadata_fields in raw_data.items():
+            fields = {} if metadata_fields is None else metadata_fields
+            if not isinstance(fields, Mapping):
+                msg = f"Expected mapping for metadata field set, got {type(fields).__name__}"
+                raise TypeError(msg)
+
+            row: dict[str, object] = {"_metadata_key": str(metadata_key)}
+            normalised_fields: dict[str, object] = {str(key): value for key, value in fields.items()}
+            row.update(normalised_fields)
+            rows.append(row)
+        return rows
+
+    if isinstance(raw_data, list):
+        rows = []
+        for idx, item in enumerate(raw_data):
+            if not isinstance(item, Mapping):
+                msg = f"Expected mapping at list index {idx}, got {type(item).__name__}"
+                raise TypeError(msg)
+            row: dict[str, object] = {str(key): value for key, value in item.items()}
+            row.setdefault("_metadata_key", f"item-{idx + 1}")
+            rows.append(row)
+        return rows
+
+    msg = f"Top-level YAML value must be a mapping or list, got {type(raw_data).__name__}"
+    raise ValueError(msg)
+
+
+def build_table(rows: list[dict[str, object]]) -> str:
+    if not rows:
+        summary = render_markdown_table(
+            [
+                ["Name", "Level", "Sourced from", "Editable", "Multiple"],
+                ["_No metadata defined yet_", "", "", "", ""],
+            ],
+        )
+        return f"## Summary\n\n{summary}\n\n## Details\n\n_No metadata defined yet_"
+
+    rows = sorted(rows, key=lambda row: str(row.get("name", "")).casefold())
+
+    summary_rows = [["Name", "Level", "Sourced from", "Editable", "Multiple"]]
+    detail_sections: list[str] = []
+
+    for index, row in enumerate(rows, start=1):
+        name = markdown_escape(row.get("name", "")) or f"Unnamed metadata {index}"
+        level = markdown_escape(row.get("level", ""))
+        sources = markdown_escape(row.get("sources", ""))
+        editable = markdown_escape(row.get("editable", ""))
+        multiple = markdown_escape(row.get("multiple", ""))
+        metadata_key = str(row.get("_metadata_key", f"item-{index}"))
+        anchor = f"metadata-{slugify(metadata_key)}"
+        summary_rows.append([f"[{name}](#{anchor})", level, sources, editable, multiple])
+
+        detail_lines = [f'<a id="{anchor}"></a>', "", f"### {name}", ""]
+
+        description = markdown_escape(row.get("description", ""))
+        if description:
+            detail_lines.append(description)
+        else:
+            detail_lines.append("_No description provided._")
+
+        detail_field_keys: list[str] = []
+        if "level" in row:
+            detail_field_keys.append("level")
+        if "sources" in row:
+            detail_field_keys.append("sources")
+        if "editable" in row:
+            detail_field_keys.append("editable")
+        if "multiple" in row:
+            detail_field_keys.append("multiple")
+        detail_field_keys.extend(
+            key
+            for key in row
+            if key not in {"_metadata_key", "name", "description", "level", "sources", "editable", "multiple"}
+        )
+
+        if detail_field_keys:
+            detail_table_rows = [
+                [format_header(key) for key in detail_field_keys],
+                [render_detail_value(key, row.get(key, "")) for key in detail_field_keys],
+            ]
+            detail_lines.extend(["", render_markdown_table(detail_table_rows)])
+
+        detail_sections.append("\n".join(detail_lines))
+
+    summary = render_markdown_table(summary_rows)
+
+    return "\n".join(
+        [
+            "## Summary",
+            "",
+            summary,
+            "",
+            "## Details",
+            "",
+            "\n\n".join(detail_sections),
+        ],
+    )
+
+
+def main() -> int:
+    if not METADATA_PATH.exists():
+        sys.stderr.write(f"Missing metadata file: {METADATA_PATH}\n")
+        return 1
+
+    if not DOC_PATH.exists():
+        sys.stderr.write(f"Missing documentation file: {DOC_PATH}\n")
+        return 1
+
+    rows = normalise_rows(yaml.safe_load(METADATA_PATH.read_text(encoding="utf-8")))
+    generated_block = "\n".join([BEGIN_MARKER, GENERATED_NOTE, "", build_table(rows), "", END_MARKER])
+
+    doc_content = DOC_PATH.read_text(encoding="utf-8")
+
+    block_pattern = re.compile(
+        rf"{re.escape(BEGIN_MARKER)}.*?{re.escape(END_MARKER)}",
+        flags=re.DOTALL,
+    )
+
+    if block_pattern.search(doc_content):
+        updated = block_pattern.sub(generated_block, doc_content)
+    else:
+        sys.stderr.write(
+            f"No document metadata table markers found. Add '{BEGIN_MARKER} ... {END_MARKER}' to the document.\n",
+        )
+        return 1
+
+    DOC_PATH.write_text(updated, encoding="utf-8")
+    sys.stdout.write(f"Updated {DOC_PATH}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/build_repo_lists
+++ b/scripts/build_repo_lists
@@ -4,6 +4,8 @@ import json
 import re
 from pathlib import Path
 
+from markdown_table_renderer import render_markdown_table
+
 _SCRIPT_DIR = Path(__file__).resolve().parent
 _REPOSITORIES_PATH = _SCRIPT_DIR / "repositories.json"
 REPOSITORIES = json.loads(_REPOSITORIES_PATH.read_text(encoding="utf-8"))
@@ -11,19 +13,6 @@ NA_STRING = "![n/a](https://img.shields.io/badge/-n%2Fa-eee)"
 GENERATED_NOTE = (
     "<!-- Generated from scripts/build_repo_lists using scripts/repositories.json. Do not edit manually. -->\n"
 )
-
-
-def render_markdown_table(rows: list[list[str]]) -> str:
-    widths = [max(len(row[index]) for row in rows) for index in range(len(rows[0]))]
-
-    def format_row(row: list[str]) -> str:
-        padded_cells = [cell.ljust(widths[index]) for index, cell in enumerate(row)]
-        return f"| {' | '.join(padded_cells)} |"
-
-    divider = "| " + " | ".join("-" * max(width, 3) for width in widths) + " |"
-    body = [format_row(row) for row in rows]
-
-    return "\n".join([body[0], divider, *body[1:]])
 
 
 dashboard_rows = [

--- a/scripts/document-metadata.yml
+++ b/scripts/document-metadata.yml
@@ -1,0 +1,166 @@
+name:
+  name: Name
+  description: The title of the document as most commonly used by humans. This _may_ vary from the exact title in the document text, for example by standardising casing.
+  level: Document body
+  sources:
+    - Parser (Document body)
+    - Metadata file
+    - EUI
+    - Stub form
+  editable: true
+  multiple: false
+  access: Document.body.name
+
+cite:
+  name: NCN
+  description: Where present, this document's Neutral Citation Number. This is a special case of identifier, which we actually want to deprecate.
+  level: Document properties, document body
+  sources:
+    - Parser (Document body)
+    - Metadata file
+    - EUI
+    - Stub form
+  editable: true
+  multiple: false
+  access: Document.identifiers.preferred(NeutralCitationNumber)
+
+court:
+  name: Court
+  description: The court which published this document. "Court" here means "any body capable of issuing a legally binding decision".
+  level: Document body
+  sources:
+    - Parser (Document body)
+    - Metadata file
+    - EUI
+    - Stub form
+  editable: true
+  multiple: false
+  access: Document.body.court
+
+jurisdiction:
+  name: Jurisdiction
+  description: The jurisdiction of the court which this decision was made under
+  level: Document body
+  sources:
+    - Parser (Document body)
+  editable: false
+  multiple: false
+  access: Document.body.jurisdiction
+
+categories:
+  name: Categories
+  description: Categories under which this document falls
+  level: Document body
+  sources:
+    - Parser (Document body)
+    - Metadata file
+  editable: false
+  multiple: false
+  access: Document.body.categories
+
+case_number:
+  name: Case number
+  description: The case number for the case this document relates to.
+  level: Document body
+  sources:
+    - Parser (Document body)
+    - Metadata file
+  editable: false
+  multiple: false
+  access: Document.body.case_number
+
+date:
+  name: Judgment date
+  description: The date the document was published, usually the date a decision was handed down.
+  level: Document body
+  sources:
+    - Parser (Document body)
+    - Metadata file
+    - EUI
+    - Stub form
+  editable: true
+  multiple: false
+  access: Document.body.document_date_as_string
+
+parties:
+  name: Parties
+  description: A list of the names of the parties involved in any particular case. This does _not_ include structured data on the nature of the party (eg defendant/appellant).
+  level: Document body
+  sources:
+    - Parser (Document body)
+    - Metadata file
+  editable: false
+  multiple: true
+
+judges:
+  name: Judges
+  description: A list of the names of the judges (or equivalent for the body) involved in any particular case.
+  level: Document body
+  sources:
+    - Parser (Document body)
+    - Metadata file
+    - Stub form
+  editable: false
+  multiple: true
+
+uri:
+  name: URI
+  description: The unique identifier for the document.
+  level: Document object (inherent property)
+  sources:
+    - System
+  editable: false
+  multiple: false
+  access: Document.uri
+
+source_name:
+  name: Source name
+  description: The name of the person who submitted the document.
+  level: Document properties (should be Submission)
+  sources:
+    - Parser (TDR metadata)
+  editable: false
+  multiple: false
+  access: Document.source_name
+
+source_email:
+  name: Source email
+  description: The email address of the person who submitted the document.
+  level: Document properties (should be Submission)
+  sources:
+    - Parser (TDR metadata)
+  editable: false
+  multiple: false
+  access: Document.source_email
+
+consignment_reference:
+  name: TDR reference
+  description: The TDR reference of the submission.
+  level: Document properties (should be Submission)
+  sources:
+    - Parser (TDR metadata)
+  editable: false
+  multiple: false
+  access: Document.consignment_reference
+
+identifiers:
+  name: Identifiers
+  description: Identifiers for a document (NCN, FCLID etc) stored within the structured identifier system.
+  level: Document properties
+  sources:
+    - Ingester
+    - EUI
+  editable: true
+  multiple: true
+  access: Document.identifiers
+
+version_annotation:
+  name: Version annotation
+  description: A (hopefully) structured JSON blob describing how and why a new version of a document came into being.
+  level: Version
+  sources:
+    - Ingester
+    - Enrichment
+  editable: false
+  multiple: false
+  access: Document.annotation

--- a/scripts/markdown_table_renderer.py
+++ b/scripts/markdown_table_renderer.py
@@ -1,0 +1,28 @@
+from collections.abc import Sequence
+
+
+def render_markdown_table(rows: Sequence[Sequence[str]]) -> str:
+    if not rows:
+        msg = "rows must contain at least one row"
+        raise ValueError(msg)
+
+    column_count = len(rows[0])
+    if column_count == 0:
+        msg = "rows must contain at least one column"
+        raise ValueError(msg)
+
+    for row in rows:
+        if len(row) != column_count:
+            msg = "all rows must have the same number of columns"
+            raise ValueError(msg)
+
+    widths = [max(len(row[index]) for row in rows) for index in range(column_count)]
+
+    def format_row(row: Sequence[str]) -> str:
+        padded_cells = [cell.ljust(widths[index]) for index, cell in enumerate(row)]
+        return f"| {' | '.join(padded_cells)} |"
+
+    divider = "| " + " | ".join("-" * max(width, 3) for width in widths) + " |"
+    body = [format_row(row) for row in rows]
+
+    return "\n".join([body[0], divider, *body[1:]])


### PR DESCRIPTION
This adds a new piece of documentation listing all the pieces of "document metadata" which exist in the system, and where they are.

The actual list is stored in a YAML file (because it works better if we structure it), and this is then rendered to nice human-readable documentation.