### PR TITLE
[FCLC-2031] Add new temporal properties to metadata documentation

### DIFF
--- a/doc/adr/0047-uncouple-document-uris-and-ncns.md
+++ b/doc/adr/0047-uncouple-document-uris-and-ncns.md
@@ -47,7 +47,7 @@ By converting identifier values to precompiled URL slugs, we can use [TDE](https
 - Document `d-1f8bcdda-5771-488d-9064-973f9f4b3c36` has an identifier `[2025] UKSC 1`, under the schema `Neutral Citation Number`
 - The `Neutral Citation Number` schema has rules for converting `[2025] UKSC 1` to the slug `uksc/2025/1`, matching the format in [ADR 4](0004-adopt-a-standardised-url-scheme.md). This is saved with the identifier and stored in the SQL lookup table.
 - When a user visits `caselaw.nationalarchives.gov.uk/uksc/2025/1`, we extract the `uksc/2025/1` slug from the URL.
-- Looking up ``uksc/2025/1` in the SQL table gives us document URL `d-1f8bcdda-5771-488d-9064-973f9f4b3c36`, which can be retrieved and returned to the user.
+- Looking up `uksc/2025/1` in the SQL table gives us document URL `d-1f8bcdda-5771-488d-9064-973f9f4b3c36`, which can be retrieved and returned to the user.
 
 #### Identifying identifiers
 

--- a/doc/document-metadata.md
+++ b/doc/document-metadata.md
@@ -7,23 +7,31 @@ This document lists all the types of metadata which can be associated with a doc
 
 ## Summary
 
-| Name                                              | Level                                      | Sourced from                                                | Editable | Multiple |
-| ------------------------------------------------- | ------------------------------------------ | ----------------------------------------------------------- | -------- | -------- |
-| [Case number](#metadata-casenumber)               | Document body                              | Parser (Document body)<br>Metadata file                     | No       | No       |
-| [Categories](#metadata-categories)                | Document body                              | Parser (Document body)<br>Metadata file                     | No       | No       |
-| [Court](#metadata-court)                          | Document body                              | Parser (Document body)<br>Metadata file<br>EUI<br>Stub form | Yes      | No       |
-| [Identifiers](#metadata-identifiers)              | Document properties                        | Ingester<br>EUI                                             | Yes      | Yes      |
-| [Judges](#metadata-judges)                        | Document body                              | Parser (Document body)<br>Metadata file<br>Stub form        | No       | Yes      |
-| [Judgment date](#metadata-date)                   | Document body                              | Parser (Document body)<br>Metadata file<br>EUI<br>Stub form | Yes      | No       |
-| [Jurisdiction](#metadata-jurisdiction)            | Document body                              | Parser (Document body)                                      | No       | No       |
-| [Name](#metadata-name)                            | Document body                              | Parser (Document body)<br>Metadata file<br>EUI<br>Stub form | Yes      | No       |
-| [NCN](#metadata-cite)                             | Document properties, document body         | Parser (Document body)<br>Metadata file<br>EUI<br>Stub form | Yes      | No       |
-| [Parties](#metadata-parties)                      | Document body                              | Parser (Document body)<br>Metadata file                     | No       | Yes      |
-| [Source email](#metadata-sourceemail)             | Document properties (should be Submission) | Parser (TDR metadata)                                       | No       | No       |
-| [Source name](#metadata-sourcename)               | Document properties (should be Submission) | Parser (TDR metadata)                                       | No       | No       |
-| [TDR reference](#metadata-consignmentreference)   | Document properties (should be Submission) | Parser (TDR metadata)                                       | No       | No       |
-| [URI](#metadata-uri)                              | Document object (inherent property)        | System                                                      | No       | No       |
-| [Version annotation](#metadata-versionannotation) | Version                                    | Ingester<br>Enrichment                                      | No       | No       |
+| Name                                                                                                                    | Level                                      | Sourced from                                                | Editable | Multiple | Implemented |
+| ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ | ----------------------------------------------------------- | -------- | -------- | ----------- |
+| [Case number](#metadata-casenumber)                                                                                     | Document body                              | Parser (Document body)<br>Metadata file                     | No       | No       | Yes         |
+| [Categories](#metadata-categories)                                                                                      | Document body                              | Parser (Document body)<br>Metadata file                     | No       | No       | Yes         |
+| [Court](#metadata-court)                                                                                                | Document body                              | Parser (Document body)<br>Metadata file<br>EUI<br>Stub form | Yes      | No       | Yes         |
+| [Document first ingested after latest publication at](#metadata-documentfirstingestionafterlatestpublicationdatetime)   | Document properties                        | Parser (TDR metadata)                                       | No       | No       | No          |
+| [Document first ingested at](#metadata-documentfirstingestiondatetime)                                                  | Document properties                        | Parser (TDR metadata)                                       | No       | No       | No          |
+| [Document first published at](#metadata-documentfirstpublisheddatetime)                                                 | Document properties                        | EUI<br>Ingester                                             | No       | No       | Yes         |
+| [Document first submitted after latest publication at](#metadata-documentfirstsubmissionafterlatestpublicationdatetime) | Document properties                        | Parser (TDR metadata)                                       | No       | No       | No          |
+| [Document first submitted at](#metadata-documentfirstsubmissiondatetime)                                                | Document properties                        | Parser (TDR metadata)                                       | No       | No       | No          |
+| [Document most recently ingested at](#metadata-documentlatestingestiondatetime)                                         | Document properties                        | Parser (TDR metadata)                                       | No       | No       | No          |
+| [Document most recently published at](#metadata-documentlatestpublisheddatetime)                                        | Document properties                        | EUI<br>Ingester                                             | No       | No       | Yes         |
+| [Document most recently submitted at](#metadata-documentlatestsubmissiondatetime)                                       | Document properties                        | Parser (TDR metadata)                                       | No       | No       | No          |
+| [Identifiers](#metadata-identifiers)                                                                                    | Document properties                        | Ingester<br>EUI                                             | Yes      | Yes      | Yes         |
+| [Judges](#metadata-judges)                                                                                              | Document body                              | Parser (Document body)<br>Metadata file<br>Stub form        | No       | Yes      | Yes         |
+| [Judgment date](#metadata-date)                                                                                         | Document body                              | Parser (Document body)<br>Metadata file<br>EUI<br>Stub form | Yes      | No       | Yes         |
+| [Jurisdiction](#metadata-jurisdiction)                                                                                  | Document body                              | Parser (Document body)                                      | No       | No       | Yes         |
+| [Name](#metadata-name)                                                                                                  | Document body                              | Parser (Document body)<br>Metadata file<br>EUI<br>Stub form | Yes      | No       | Yes         |
+| [NCN](#metadata-cite)                                                                                                   | Document properties, document body         | Parser (Document body)<br>Metadata file<br>EUI<br>Stub form | Yes      | No       | Yes         |
+| [Parties](#metadata-parties)                                                                                            | Document body                              | Parser (Document body)<br>Metadata file                     | No       | Yes      | Yes         |
+| [Source email](#metadata-sourceemail)                                                                                   | Document properties (should be Submission) | Parser (TDR metadata)                                       | No       | No       | Yes         |
+| [Source name](#metadata-sourcename)                                                                                     | Document properties (should be Submission) | Parser (TDR metadata)                                       | No       | No       | Yes         |
+| [TDR reference](#metadata-consignmentreference)                                                                         | Document properties (should be Submission) | Parser (TDR metadata)                                       | No       | No       | Yes         |
+| [URI](#metadata-uri)                                                                                                    | Document object (inherent property)        | System                                                      | No       | No       | Yes         |
+| [Version annotation](#metadata-versionannotation)                                                                       | Version                                    | Ingester<br>Enrichment                                      | No       | No       | Yes         |
 
 ## Details
 
@@ -33,9 +41,9 @@ This document lists all the types of metadata which can be associated with a doc
 
 The case number for the case this document relates to.
 
-| Level         | Sourced from                            | Editable | Multiple | Access via                  |
-| ------------- | --------------------------------------- | -------- | -------- | --------------------------- |
-| Document body | Parser (Document body)<br>Metadata file | No       | No       | `Document.body.case_number` |
+| Level         | Sourced from                            | Editable | Multiple | Implemented | Access via                  |
+| ------------- | --------------------------------------- | -------- | -------- | ----------- | --------------------------- |
+| Document body | Parser (Document body)<br>Metadata file | No       | No       | Yes         | `Document.body.case_number` |
 
 <a id="metadata-categories"></a>
 
@@ -43,9 +51,9 @@ The case number for the case this document relates to.
 
 Categories under which this document falls
 
-| Level         | Sourced from                            | Editable | Multiple | Access via                 |
-| ------------- | --------------------------------------- | -------- | -------- | -------------------------- |
-| Document body | Parser (Document body)<br>Metadata file | No       | No       | `Document.body.categories` |
+| Level         | Sourced from                            | Editable | Multiple | Implemented | Access via                 |
+| ------------- | --------------------------------------- | -------- | -------- | ----------- | -------------------------- |
+| Document body | Parser (Document body)<br>Metadata file | No       | No       | Yes         | `Document.body.categories` |
 
 <a id="metadata-court"></a>
 
@@ -53,9 +61,89 @@ Categories under which this document falls
 
 The court which published this document. "Court" here means "any body capable of issuing a legally binding decision".
 
-| Level         | Sourced from                                                | Editable | Multiple | Access via            |
-| ------------- | ----------------------------------------------------------- | -------- | -------- | --------------------- |
-| Document body | Parser (Document body)<br>Metadata file<br>EUI<br>Stub form | Yes      | No       | `Document.body.court` |
+| Level         | Sourced from                                                | Editable | Multiple | Implemented | Access via            |
+| ------------- | ----------------------------------------------------------- | -------- | -------- | ----------- | --------------------- |
+| Document body | Parser (Document body)<br>Metadata file<br>EUI<br>Stub form | Yes      | No       | Yes         | `Document.body.court` |
+
+<a id="metadata-documentfirstingestionafterlatestpublicationdatetime"></a>
+
+### Document first ingested after latest publication at
+
+The date and time the first version of this document following the latest publication was ingested into FCL.
+
+| Level               | Sourced from          | Editable | Multiple | Implemented |
+| ------------------- | --------------------- | -------- | -------- | ----------- |
+| Document properties | Parser (TDR metadata) | No       | No       | No          |
+
+<a id="metadata-documentfirstingestiondatetime"></a>
+
+### Document first ingested at
+
+The date and time the first version of this document was ingested into FCL.
+
+| Level               | Sourced from          | Editable | Multiple | Implemented |
+| ------------------- | --------------------- | -------- | -------- | ----------- |
+| Document properties | Parser (TDR metadata) | No       | No       | No          |
+
+<a id="metadata-documentfirstpublisheddatetime"></a>
+
+### Document first published at
+
+The date and time the document was first published on Find Case Law.
+
+| Level               | Sourced from    | Editable | Multiple | Implemented | Access via                          |
+| ------------------- | --------------- | -------- | -------- | ----------- | ----------------------------------- |
+| Document properties | EUI<br>Ingester | No       | No       | Yes         | `Document.first_published_datetime` |
+
+<a id="metadata-documentfirstsubmissionafterlatestpublicationdatetime"></a>
+
+### Document first submitted after latest publication at
+
+The date and time the first version of this document following the latest publication was submitted through TDR.
+
+| Level               | Sourced from          | Editable | Multiple | Implemented |
+| ------------------- | --------------------- | -------- | -------- | ----------- |
+| Document properties | Parser (TDR metadata) | No       | No       | No          |
+
+<a id="metadata-documentfirstsubmissiondatetime"></a>
+
+### Document first submitted at
+
+The date and time the first version of this document was submitted through TDR.
+
+| Level               | Sourced from          | Editable | Multiple | Implemented |
+| ------------------- | --------------------- | -------- | -------- | ----------- |
+| Document properties | Parser (TDR metadata) | No       | No       | No          |
+
+<a id="metadata-documentlatestingestiondatetime"></a>
+
+### Document most recently ingested at
+
+The date and time the most recent version of this document was ingested into FCL.
+
+| Level               | Sourced from          | Editable | Multiple | Implemented |
+| ------------------- | --------------------- | -------- | -------- | ----------- |
+| Document properties | Parser (TDR metadata) | No       | No       | No          |
+
+<a id="metadata-documentlatestpublisheddatetime"></a>
+
+### Document most recently published at
+
+The date and time the document was most recently published on Find Case Law.
+
+| Level               | Sourced from    | Editable | Multiple | Implemented | Access via                          |
+| ------------------- | --------------- | -------- | -------- | ----------- | ----------------------------------- |
+| Document properties | EUI<br>Ingester | No       | No       | Yes         | `Document.first_published_datetime` |
+
+<a id="metadata-documentlatestsubmissiondatetime"></a>
+
+### Document most recently submitted at
+
+The date and time the most recent version of this document was submitted through TDR.
+
+| Level               | Sourced from          | Editable | Multiple | Implemented |
+| ------------------- | --------------------- | -------- | -------- | ----------- |
+| Document properties | Parser (TDR metadata) | No       | No       | No          |
 
 <a id="metadata-identifiers"></a>
 
@@ -63,9 +151,9 @@ The court which published this document. "Court" here means "any body capable of
 
 Identifiers for a document (NCN, FCLID etc) stored within the structured identifier system.
 
-| Level               | Sourced from    | Editable | Multiple | Access via             |
-| ------------------- | --------------- | -------- | -------- | ---------------------- |
-| Document properties | Ingester<br>EUI | Yes      | Yes      | `Document.identifiers` |
+| Level               | Sourced from    | Editable | Multiple | Implemented | Access via             |
+| ------------------- | --------------- | -------- | -------- | ----------- | ---------------------- |
+| Document properties | Ingester<br>EUI | Yes      | Yes      | Yes         | `Document.identifiers` |
 
 <a id="metadata-judges"></a>
 
@@ -73,9 +161,9 @@ Identifiers for a document (NCN, FCLID etc) stored within the structured identif
 
 A list of the names of the judges (or equivalent for the body) involved in any particular case.
 
-| Level         | Sourced from                                         | Editable | Multiple |
-| ------------- | ---------------------------------------------------- | -------- | -------- |
-| Document body | Parser (Document body)<br>Metadata file<br>Stub form | No       | Yes      |
+| Level         | Sourced from                                         | Editable | Multiple | Implemented |
+| ------------- | ---------------------------------------------------- | -------- | -------- | ----------- |
+| Document body | Parser (Document body)<br>Metadata file<br>Stub form | No       | Yes      | Yes         |
 
 <a id="metadata-date"></a>
 
@@ -83,9 +171,9 @@ A list of the names of the judges (or equivalent for the body) involved in any p
 
 The date the document was published, usually the date a decision was handed down.
 
-| Level         | Sourced from                                                | Editable | Multiple | Access via                              |
-| ------------- | ----------------------------------------------------------- | -------- | -------- | --------------------------------------- |
-| Document body | Parser (Document body)<br>Metadata file<br>EUI<br>Stub form | Yes      | No       | `Document.body.document_date_as_string` |
+| Level         | Sourced from                                                | Editable | Multiple | Implemented | Access via                              |
+| ------------- | ----------------------------------------------------------- | -------- | -------- | ----------- | --------------------------------------- |
+| Document body | Parser (Document body)<br>Metadata file<br>EUI<br>Stub form | Yes      | No       | Yes         | `Document.body.document_date_as_string` |
 
 <a id="metadata-jurisdiction"></a>
 
@@ -93,9 +181,9 @@ The date the document was published, usually the date a decision was handed down
 
 The jurisdiction of the court which this decision was made under
 
-| Level         | Sourced from           | Editable | Multiple | Access via                   |
-| ------------- | ---------------------- | -------- | -------- | ---------------------------- |
-| Document body | Parser (Document body) | No       | No       | `Document.body.jurisdiction` |
+| Level         | Sourced from           | Editable | Multiple | Implemented | Access via                   |
+| ------------- | ---------------------- | -------- | -------- | ----------- | ---------------------------- |
+| Document body | Parser (Document body) | No       | No       | Yes         | `Document.body.jurisdiction` |
 
 <a id="metadata-name"></a>
 
@@ -103,9 +191,9 @@ The jurisdiction of the court which this decision was made under
 
 The title of the document as most commonly used by humans. This _may_ vary from the exact title in the document text, for example by standardising casing.
 
-| Level         | Sourced from                                                | Editable | Multiple | Access via           |
-| ------------- | ----------------------------------------------------------- | -------- | -------- | -------------------- |
-| Document body | Parser (Document body)<br>Metadata file<br>EUI<br>Stub form | Yes      | No       | `Document.body.name` |
+| Level         | Sourced from                                                | Editable | Multiple | Implemented | Access via           |
+| ------------- | ----------------------------------------------------------- | -------- | -------- | ----------- | -------------------- |
+| Document body | Parser (Document body)<br>Metadata file<br>EUI<br>Stub form | Yes      | No       | Yes         | `Document.body.name` |
 
 <a id="metadata-cite"></a>
 
@@ -113,9 +201,9 @@ The title of the document as most commonly used by humans. This _may_ vary from 
 
 Where present, this document's Neutral Citation Number. This is a special case of identifier, which we actually want to deprecate.
 
-| Level                              | Sourced from                                                | Editable | Multiple | Access via                                              |
-| ---------------------------------- | ----------------------------------------------------------- | -------- | -------- | ------------------------------------------------------- |
-| Document properties, document body | Parser (Document body)<br>Metadata file<br>EUI<br>Stub form | Yes      | No       | `Document.identifiers.preferred(NeutralCitationNumber)` |
+| Level                              | Sourced from                                                | Editable | Multiple | Implemented | Access via                                              |
+| ---------------------------------- | ----------------------------------------------------------- | -------- | -------- | ----------- | ------------------------------------------------------- |
+| Document properties, document body | Parser (Document body)<br>Metadata file<br>EUI<br>Stub form | Yes      | No       | Yes         | `Document.identifiers.preferred(NeutralCitationNumber)` |
 
 <a id="metadata-parties"></a>
 
@@ -123,9 +211,9 @@ Where present, this document's Neutral Citation Number. This is a special case o
 
 A list of the names of the parties involved in any particular case. This does _not_ include structured data on the nature of the party (eg defendant/appellant).
 
-| Level         | Sourced from                            | Editable | Multiple |
-| ------------- | --------------------------------------- | -------- | -------- |
-| Document body | Parser (Document body)<br>Metadata file | No       | Yes      |
+| Level         | Sourced from                            | Editable | Multiple | Implemented |
+| ------------- | --------------------------------------- | -------- | -------- | ----------- |
+| Document body | Parser (Document body)<br>Metadata file | No       | Yes      | Yes         |
 
 <a id="metadata-sourceemail"></a>
 
@@ -133,9 +221,9 @@ A list of the names of the parties involved in any particular case. This does _n
 
 The email address of the person who submitted the document.
 
-| Level                                      | Sourced from          | Editable | Multiple | Access via              |
-| ------------------------------------------ | --------------------- | -------- | -------- | ----------------------- |
-| Document properties (should be Submission) | Parser (TDR metadata) | No       | No       | `Document.source_email` |
+| Level                                      | Sourced from          | Editable | Multiple | Implemented | Access via              |
+| ------------------------------------------ | --------------------- | -------- | -------- | ----------- | ----------------------- |
+| Document properties (should be Submission) | Parser (TDR metadata) | No       | No       | Yes         | `Document.source_email` |
 
 <a id="metadata-sourcename"></a>
 
@@ -143,9 +231,9 @@ The email address of the person who submitted the document.
 
 The name of the person who submitted the document.
 
-| Level                                      | Sourced from          | Editable | Multiple | Access via             |
-| ------------------------------------------ | --------------------- | -------- | -------- | ---------------------- |
-| Document properties (should be Submission) | Parser (TDR metadata) | No       | No       | `Document.source_name` |
+| Level                                      | Sourced from          | Editable | Multiple | Implemented | Access via             |
+| ------------------------------------------ | --------------------- | -------- | -------- | ----------- | ---------------------- |
+| Document properties (should be Submission) | Parser (TDR metadata) | No       | No       | Yes         | `Document.source_name` |
 
 <a id="metadata-consignmentreference"></a>
 
@@ -153,9 +241,9 @@ The name of the person who submitted the document.
 
 The TDR reference of the submission.
 
-| Level                                      | Sourced from          | Editable | Multiple | Access via                       |
-| ------------------------------------------ | --------------------- | -------- | -------- | -------------------------------- |
-| Document properties (should be Submission) | Parser (TDR metadata) | No       | No       | `Document.consignment_reference` |
+| Level                                      | Sourced from          | Editable | Multiple | Implemented | Access via                       |
+| ------------------------------------------ | --------------------- | -------- | -------- | ----------- | -------------------------------- |
+| Document properties (should be Submission) | Parser (TDR metadata) | No       | No       | Yes         | `Document.consignment_reference` |
 
 <a id="metadata-uri"></a>
 
@@ -163,9 +251,9 @@ The TDR reference of the submission.
 
 The unique identifier for the document.
 
-| Level                               | Sourced from | Editable | Multiple | Access via     |
-| ----------------------------------- | ------------ | -------- | -------- | -------------- |
-| Document object (inherent property) | System       | No       | No       | `Document.uri` |
+| Level                               | Sourced from | Editable | Multiple | Implemented | Access via     |
+| ----------------------------------- | ------------ | -------- | -------- | ----------- | -------------- |
+| Document object (inherent property) | System       | No       | No       | Yes         | `Document.uri` |
 
 <a id="metadata-versionannotation"></a>
 
@@ -173,8 +261,8 @@ The unique identifier for the document.
 
 A (hopefully) structured JSON blob describing how and why a new version of a document came into being.
 
-| Level   | Sourced from           | Editable | Multiple | Access via            |
-| ------- | ---------------------- | -------- | -------- | --------------------- |
-| Version | Ingester<br>Enrichment | No       | No       | `Document.annotation` |
+| Level   | Sourced from           | Editable | Multiple | Implemented | Access via            |
+| ------- | ---------------------- | -------- | -------- | ----------- | --------------------- |
+| Version | Ingester<br>Enrichment | No       | No       | Yes         | `Document.annotation` |
 
 <!-- End document metadata table -->

--- a/scripts/build_document_metadata_table
+++ b/scripts/build_document_metadata_table
@@ -99,15 +99,15 @@ def build_table(rows: list[dict[str, object]]) -> str:
     if not rows:
         summary = render_markdown_table(
             [
-                ["Name", "Level", "Sourced from", "Editable", "Multiple"],
-                ["_No metadata defined yet_", "", "", "", ""],
+                ["Name", "Level", "Sourced from", "Editable", "Multiple", "Implemented"],
+                ["_No metadata defined yet_", "", "", "", "", ""],
             ],
         )
         return f"## Summary\n\n{summary}\n\n## Details\n\n_No metadata defined yet_"
 
     rows = sorted(rows, key=lambda row: str(row.get("name", "")).casefold())
 
-    summary_rows = [["Name", "Level", "Sourced from", "Editable", "Multiple"]]
+    summary_rows = [["Name", "Level", "Sourced from", "Editable", "Multiple", "Implemented"]]
     detail_sections: list[str] = []
 
     for index, row in enumerate(rows, start=1):
@@ -116,9 +116,10 @@ def build_table(rows: list[dict[str, object]]) -> str:
         sources = markdown_escape(row.get("sources", ""))
         editable = markdown_escape(row.get("editable", ""))
         multiple = markdown_escape(row.get("multiple", ""))
+        implemented = markdown_escape(row.get("implemented", ""))
         metadata_key = str(row.get("_metadata_key", f"item-{index}"))
         anchor = f"metadata-{slugify(metadata_key)}"
-        summary_rows.append([f"[{name}](#{anchor})", level, sources, editable, multiple])
+        summary_rows.append([f"[{name}](#{anchor})", level, sources, editable, multiple, implemented])
 
         detail_lines = [f'<a id="{anchor}"></a>', "", f"### {name}", ""]
 
@@ -137,10 +138,13 @@ def build_table(rows: list[dict[str, object]]) -> str:
             detail_field_keys.append("editable")
         if "multiple" in row:
             detail_field_keys.append("multiple")
+        if "implemented" in row:
+            detail_field_keys.append("implemented")
         detail_field_keys.extend(
             key
             for key in row
-            if key not in {"_metadata_key", "name", "description", "level", "sources", "editable", "multiple"}
+            if key
+            not in {"_metadata_key", "name", "description", "level", "sources", "editable", "multiple", "implemented"}
         )
 
         if detail_field_keys:

--- a/scripts/document-metadata.yml
+++ b/scripts/document-metadata.yml
@@ -9,6 +9,7 @@ name:
     - Stub form
   editable: true
   multiple: false
+  implemented: true
   access: Document.body.name
 
 cite:
@@ -22,6 +23,7 @@ cite:
     - Stub form
   editable: true
   multiple: false
+  implemented: true
   access: Document.identifiers.preferred(NeutralCitationNumber)
 
 court:
@@ -35,6 +37,7 @@ court:
     - Stub form
   editable: true
   multiple: false
+  implemented: true
   access: Document.body.court
 
 jurisdiction:
@@ -45,6 +48,7 @@ jurisdiction:
     - Parser (Document body)
   editable: false
   multiple: false
+  implemented: true
   access: Document.body.jurisdiction
 
 categories:
@@ -56,6 +60,7 @@ categories:
     - Metadata file
   editable: false
   multiple: false
+  implemented: true
   access: Document.body.categories
 
 case_number:
@@ -67,6 +72,7 @@ case_number:
     - Metadata file
   editable: false
   multiple: false
+  implemented: true
   access: Document.body.case_number
 
 date:
@@ -80,6 +86,7 @@ date:
     - Stub form
   editable: true
   multiple: false
+  implemented: true
   access: Document.body.document_date_as_string
 
 parties:
@@ -91,6 +98,7 @@ parties:
     - Metadata file
   editable: false
   multiple: true
+  implemented: true
 
 judges:
   name: Judges
@@ -102,6 +110,7 @@ judges:
     - Stub form
   editable: false
   multiple: true
+  implemented: true
 
 uri:
   name: URI
@@ -111,6 +120,7 @@ uri:
     - System
   editable: false
   multiple: false
+  implemented: true
   access: Document.uri
 
 source_name:
@@ -121,6 +131,7 @@ source_name:
     - Parser (TDR metadata)
   editable: false
   multiple: false
+  implemented: true
   access: Document.source_name
 
 source_email:
@@ -131,6 +142,7 @@ source_email:
     - Parser (TDR metadata)
   editable: false
   multiple: false
+  implemented: true
   access: Document.source_email
 
 consignment_reference:
@@ -141,6 +153,7 @@ consignment_reference:
     - Parser (TDR metadata)
   editable: false
   multiple: false
+  implemented: true
   access: Document.consignment_reference
 
 identifiers:
@@ -152,6 +165,7 @@ identifiers:
     - EUI
   editable: true
   multiple: true
+  implemented: true
   access: Document.identifiers
 
 version_annotation:
@@ -163,4 +177,89 @@ version_annotation:
     - Enrichment
   editable: false
   multiple: false
+  implemented: true
   access: Document.annotation
+
+document_first_submission_datetime:
+  name: Document first submitted at
+  description: The date and time the first version of this document was submitted through TDR.
+  level: Document properties
+  sources:
+    - Parser (TDR metadata)
+  editable: false
+  multiple: false
+  implemented: false
+
+document_first_submission_after_latest_publication_datetime:
+  name: Document first submitted after latest publication at
+  description: The date and time the first version of this document following the latest publication was submitted through TDR.
+  level: Document properties
+  sources:
+    - Parser (TDR metadata)
+  editable: false
+  multiple: false
+  implemented: false
+
+document_latest_submission_datetime:
+  name: Document most recently submitted at
+  description: The date and time the most recent version of this document was submitted through TDR.
+  level: Document properties
+  sources:
+    - Parser (TDR metadata)
+  editable: false
+  multiple: false
+  implemented: false
+
+document_first_ingestion_datetime:
+  name: Document first ingested at
+  description: The date and time the first version of this document was ingested into FCL.
+  level: Document properties
+  sources:
+    - Parser (TDR metadata)
+  editable: false
+  multiple: false
+  implemented: false
+
+document_first_ingestion_after_latest_publication_datetime:
+  name: Document first ingested after latest publication at
+  description: The date and time the first version of this document following the latest publication was ingested into FCL.
+  level: Document properties
+  sources:
+    - Parser (TDR metadata)
+  editable: false
+  multiple: false
+  implemented: false
+
+document_latest_ingestion_datetime:
+  name: Document most recently ingested at
+  description: The date and time the most recent version of this document was ingested into FCL.
+  level: Document properties
+  sources:
+    - Parser (TDR metadata)
+  editable: false
+  multiple: false
+  implemented: false
+
+document_first_published_datetime:
+  name: Document first published at
+  description: The date and time the document was first published on Find Case Law.
+  level: Document properties
+  sources:
+    - EUI
+    - Ingester
+  editable: false
+  multiple: false
+  implemented: yes
+  access: Document.first_published_datetime
+
+document_latest_published_datetime:
+  name: Document most recently published at
+  description: The date and time the document was most recently published on Find Case Law.
+  level: Document properties
+  sources:
+    - EUI
+    - Ingester
+  editable: false
+  multiple: false
+  implemented: yes
+  access: Document.first_published_datetime


### PR DESCRIPTION
Add some missing temporal metadata fields to the documentation so we have a reference for implementation.

Also, we add an `implemented` flag to keep track of these things.