### PR TITLE
Add ':automergeDigest' to configuration

### DIFF
--- a/default.json
+++ b/default.json
@@ -4,6 +4,7 @@
     "config:best-practices",
     ":automergeLinters",
     ":automergeMinor",
+    ":automergeDigest",
     ":automergePr",
     ":automergeRequireAllStatusChecks",
     ":automergeTesters",
@@ -27,11 +28,6 @@
     }
   ],
   "packageRules": [
-    {
-      "matchManagers": ["dockerfile"],
-      "matchUpdateTypes": ["digest"],
-      "automerge": true
-    },
     {
       "matchDatasources": ["npm"],
       "minimumReleaseAge": "3 days"


### PR DESCRIPTION
Added ':automergeDigest' to the extends array in default.json so that digests in our docker-compose are automatically merged as long as CI passes.