### PR TITLE
[FCLC-2101] Document new metadata layer-based access for values currently in document body

### DIFF
--- a/doc/document-metadata.md
+++ b/doc/document-metadata.md
@@ -43,9 +43,9 @@ For document body metadata that is exposed through the API client, use `Document
 
 The case number for the case this document relates to.
 
-| Level         | Sourced from                            | Editable | Multiple | Implemented | Access via                               | XML extraction via        |
-| ------------- | --------------------------------------- | -------- | -------- | ----------- | ---------------------------------------- | ------------------------- |
-| Document body | Parser (Document body)<br>Metadata file | No       | No       | Yes         | `Document.metadata["case_number"].value` | Document.body.case_number |
+| Level         | Sourced from                            | Editable | Multiple | Implemented | Access via                               | XML extraction via          |
+| ------------- | --------------------------------------- | -------- | -------- | ----------- | ---------------------------------------- | --------------------------- |
+| Document body | Parser (Document body)<br>Metadata file | No       | No       | Yes         | `Document.metadata["case_number"].value` | `Document.body.case_number` |
 
 <a id="metadata-categories"></a>
 
@@ -53,9 +53,9 @@ The case number for the case this document relates to.
 
 Categories under which this document falls
 
-| Level         | Sourced from                            | Editable | Multiple | Implemented | Access via                               | XML extraction via       |
-| ------------- | --------------------------------------- | -------- | -------- | ----------- | ---------------------------------------- | ------------------------ |
-| Document body | Parser (Document body)<br>Metadata file | No       | Yes      | Yes         | `Document.metadata["categories"].values` | Document.body.categories |
+| Level         | Sourced from                            | Editable | Multiple | Implemented | Access via                               | XML extraction via         |
+| ------------- | --------------------------------------- | -------- | -------- | ----------- | ---------------------------------------- | -------------------------- |
+| Document body | Parser (Document body)<br>Metadata file | No       | Yes      | Yes         | `Document.metadata["categories"].values` | `Document.body.categories` |
 
 <a id="metadata-court"></a>
 
@@ -63,9 +63,9 @@ Categories under which this document falls
 
 The court which published this document. "Court" here means "any body capable of issuing a legally binding decision".
 
-| Level         | Sourced from                                                | Editable | Multiple | Implemented | Access via                         | XML extraction via  |
-| ------------- | ----------------------------------------------------------- | -------- | -------- | ----------- | ---------------------------------- | ------------------- |
-| Document body | Parser (Document body)<br>Metadata file<br>EUI<br>Stub form | Yes      | No       | Yes         | `Document.metadata["court"].value` | Document.body.court |
+| Level         | Sourced from                                                | Editable | Multiple | Implemented | Access via                         | XML extraction via    |
+| ------------- | ----------------------------------------------------------- | -------- | -------- | ----------- | ---------------------------------- | --------------------- |
+| Document body | Parser (Document body)<br>Metadata file<br>EUI<br>Stub form | Yes      | No       | Yes         | `Document.metadata["court"].value` | `Document.body.court` |
 
 <a id="metadata-documentfirstingestionafterlatestpublicationdatetime"></a>
 
@@ -173,9 +173,9 @@ A list of the names of the judges (or equivalent for the body) involved in any p
 
 The date the document was published, usually the date a decision was handed down.
 
-| Level         | Sourced from                                                | Editable | Multiple | Implemented | Access via                                                                 | XML extraction via                  |
-| ------------- | ----------------------------------------------------------- | -------- | -------- | ----------- | -------------------------------------------------------------------------- | ----------------------------------- |
-| Document body | Parser (Document body)<br>Metadata file<br>EUI<br>Stub form | Yes      | No       | Yes         | `Document.metadata["date"].value`<br>`Document.metadata["date"].as_string` | Document.body.document_date_as_date |
+| Level         | Sourced from                                                | Editable | Multiple | Implemented | Access via                                                                 | XML extraction via                    |
+| ------------- | ----------------------------------------------------------- | -------- | -------- | ----------- | -------------------------------------------------------------------------- | ------------------------------------- |
+| Document body | Parser (Document body)<br>Metadata file<br>EUI<br>Stub form | Yes      | No       | Yes         | `Document.metadata["date"].value`<br>`Document.metadata["date"].as_string` | `Document.body.document_date_as_date` |
 
 <a id="metadata-jurisdiction"></a>
 
@@ -183,9 +183,9 @@ The date the document was published, usually the date a decision was handed down
 
 The jurisdiction of the court which this decision was made under
 
-| Level         | Sourced from           | Editable | Multiple | Implemented | Access via                                | XML extraction via         |
-| ------------- | ---------------------- | -------- | -------- | ----------- | ----------------------------------------- | -------------------------- |
-| Document body | Parser (Document body) | No       | No       | Yes         | `Document.metadata["jurisdiction"].value` | Document.body.jurisdiction |
+| Level         | Sourced from           | Editable | Multiple | Implemented | Access via                                | XML extraction via           |
+| ------------- | ---------------------- | -------- | -------- | ----------- | ----------------------------------------- | ---------------------------- |
+| Document body | Parser (Document body) | No       | No       | Yes         | `Document.metadata["jurisdiction"].value` | `Document.body.jurisdiction` |
 
 <a id="metadata-name"></a>
 
@@ -193,9 +193,9 @@ The jurisdiction of the court which this decision was made under
 
 The title of the document as most commonly used by humans. This _may_ vary from the exact title in the document text, for example by standardising casing.
 
-| Level         | Sourced from                                                | Editable | Multiple | Implemented | Access via                        | XML extraction via |
-| ------------- | ----------------------------------------------------------- | -------- | -------- | ----------- | --------------------------------- | ------------------ |
-| Document body | Parser (Document body)<br>Metadata file<br>EUI<br>Stub form | Yes      | No       | Yes         | `Document.metadata["name"].value` | Document.body.name |
+| Level         | Sourced from                                                | Editable | Multiple | Implemented | Access via                        | XML extraction via   |
+| ------------- | ----------------------------------------------------------- | -------- | -------- | ----------- | --------------------------------- | -------------------- |
+| Document body | Parser (Document body)<br>Metadata file<br>EUI<br>Stub form | Yes      | No       | Yes         | `Document.metadata["name"].value` | `Document.body.name` |
 
 <a id="metadata-cite"></a>
 

--- a/doc/document-metadata.md
+++ b/doc/document-metadata.md
@@ -2,6 +2,8 @@
 
 This document lists all the types of metadata which can be associated with a document, if that metadata exists at the level of document, submission or version, how to access that metadata, how that metadata is sourced, and if that metadata should be considered editable.
 
+For document body metadata that is exposed through the API client, use `Document.metadata` as the standard access layer. Each entry is a typed metadata object (for example `NameMetadata`) whose properties delegate to the underlying XML extraction on `Document.body`. The `Document.body` paths remain the implementation layer for reading values directly from the Akoma Ntoso XML.
+
 <!-- Begin document metadata table -->
 <!-- Generated from scripts/build_document_metadata_table using scripts/document-metadata.yml. Do not edit manually. -->
 
@@ -10,7 +12,7 @@ This document lists all the types of metadata which can be associated with a doc
 | Name                                                                                                                    | Level                                      | Sourced from                                                | Editable | Multiple | Implemented |
 | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ | ----------------------------------------------------------- | -------- | -------- | ----------- |
 | [Case number](#metadata-casenumber)                                                                                     | Document body                              | Parser (Document body)<br>Metadata file                     | No       | No       | Yes         |
-| [Categories](#metadata-categories)                                                                                      | Document body                              | Parser (Document body)<br>Metadata file                     | No       | No       | Yes         |
+| [Categories](#metadata-categories)                                                                                      | Document body                              | Parser (Document body)<br>Metadata file                     | No       | Yes      | Yes         |
 | [Court](#metadata-court)                                                                                                | Document body                              | Parser (Document body)<br>Metadata file<br>EUI<br>Stub form | Yes      | No       | Yes         |
 | [Document first ingested after latest publication at](#metadata-documentfirstingestionafterlatestpublicationdatetime)   | Document properties                        | Parser (TDR metadata)                                       | No       | No       | No          |
 | [Document first ingested at](#metadata-documentfirstingestiondatetime)                                                  | Document properties                        | Parser (TDR metadata)                                       | No       | No       | No          |
@@ -18,7 +20,7 @@ This document lists all the types of metadata which can be associated with a doc
 | [Document first submitted after latest publication at](#metadata-documentfirstsubmissionafterlatestpublicationdatetime) | Document properties                        | Parser (TDR metadata)                                       | No       | No       | No          |
 | [Document first submitted at](#metadata-documentfirstsubmissiondatetime)                                                | Document properties                        | Parser (TDR metadata)                                       | No       | No       | No          |
 | [Document most recently ingested at](#metadata-documentlatestingestiondatetime)                                         | Document properties                        | Parser (TDR metadata)                                       | No       | No       | No          |
-| [Document most recently published at](#metadata-documentlatestpublisheddatetime)                                        | Document properties                        | EUI<br>Ingester                                             | No       | No       | Yes         |
+| [Document most recently published at](#metadata-documentlatestpublisheddatetime)                                        | Document properties                        | EUI<br>Ingester                                             | No       | No       | No          |
 | [Document most recently submitted at](#metadata-documentlatestsubmissiondatetime)                                       | Document properties                        | Parser (TDR metadata)                                       | No       | No       | No          |
 | [Identifiers](#metadata-identifiers)                                                                                    | Document properties                        | Ingester<br>EUI                                             | Yes      | Yes      | Yes         |
 | [Judges](#metadata-judges)                                                                                              | Document body                              | Parser (Document body)<br>Metadata file<br>Stub form        | No       | Yes      | Yes         |
@@ -41,9 +43,9 @@ This document lists all the types of metadata which can be associated with a doc
 
 The case number for the case this document relates to.
 
-| Level         | Sourced from                            | Editable | Multiple | Implemented | Access via                  |
-| ------------- | --------------------------------------- | -------- | -------- | ----------- | --------------------------- |
-| Document body | Parser (Document body)<br>Metadata file | No       | No       | Yes         | `Document.body.case_number` |
+| Level         | Sourced from                            | Editable | Multiple | Implemented | Access via                               | XML extraction via        |
+| ------------- | --------------------------------------- | -------- | -------- | ----------- | ---------------------------------------- | ------------------------- |
+| Document body | Parser (Document body)<br>Metadata file | No       | No       | Yes         | `Document.metadata["case_number"].value` | Document.body.case_number |
 
 <a id="metadata-categories"></a>
 
@@ -51,9 +53,9 @@ The case number for the case this document relates to.
 
 Categories under which this document falls
 
-| Level         | Sourced from                            | Editable | Multiple | Implemented | Access via                 |
-| ------------- | --------------------------------------- | -------- | -------- | ----------- | -------------------------- |
-| Document body | Parser (Document body)<br>Metadata file | No       | No       | Yes         | `Document.body.categories` |
+| Level         | Sourced from                            | Editable | Multiple | Implemented | Access via                               | XML extraction via       |
+| ------------- | --------------------------------------- | -------- | -------- | ----------- | ---------------------------------------- | ------------------------ |
+| Document body | Parser (Document body)<br>Metadata file | No       | Yes      | Yes         | `Document.metadata["categories"].values` | Document.body.categories |
 
 <a id="metadata-court"></a>
 
@@ -61,9 +63,9 @@ Categories under which this document falls
 
 The court which published this document. "Court" here means "any body capable of issuing a legally binding decision".
 
-| Level         | Sourced from                                                | Editable | Multiple | Implemented | Access via            |
-| ------------- | ----------------------------------------------------------- | -------- | -------- | ----------- | --------------------- |
-| Document body | Parser (Document body)<br>Metadata file<br>EUI<br>Stub form | Yes      | No       | Yes         | `Document.body.court` |
+| Level         | Sourced from                                                | Editable | Multiple | Implemented | Access via                         | XML extraction via  |
+| ------------- | ----------------------------------------------------------- | -------- | -------- | ----------- | ---------------------------------- | ------------------- |
+| Document body | Parser (Document body)<br>Metadata file<br>EUI<br>Stub form | Yes      | No       | Yes         | `Document.metadata["court"].value` | Document.body.court |
 
 <a id="metadata-documentfirstingestionafterlatestpublicationdatetime"></a>
 
@@ -131,9 +133,9 @@ The date and time the most recent version of this document was ingested into FCL
 
 The date and time the document was most recently published on Find Case Law.
 
-| Level               | Sourced from    | Editable | Multiple | Implemented | Access via                          |
-| ------------------- | --------------- | -------- | -------- | ----------- | ----------------------------------- |
-| Document properties | EUI<br>Ingester | No       | No       | Yes         | `Document.first_published_datetime` |
+| Level               | Sourced from    | Editable | Multiple | Implemented |
+| ------------------- | --------------- | -------- | -------- | ----------- |
+| Document properties | EUI<br>Ingester | No       | No       | No          |
 
 <a id="metadata-documentlatestsubmissiondatetime"></a>
 
@@ -171,9 +173,9 @@ A list of the names of the judges (or equivalent for the body) involved in any p
 
 The date the document was published, usually the date a decision was handed down.
 
-| Level         | Sourced from                                                | Editable | Multiple | Implemented | Access via                              |
-| ------------- | ----------------------------------------------------------- | -------- | -------- | ----------- | --------------------------------------- |
-| Document body | Parser (Document body)<br>Metadata file<br>EUI<br>Stub form | Yes      | No       | Yes         | `Document.body.document_date_as_string` |
+| Level         | Sourced from                                                | Editable | Multiple | Implemented | Access via                                                                 | XML extraction via                  |
+| ------------- | ----------------------------------------------------------- | -------- | -------- | ----------- | -------------------------------------------------------------------------- | ----------------------------------- |
+| Document body | Parser (Document body)<br>Metadata file<br>EUI<br>Stub form | Yes      | No       | Yes         | `Document.metadata["date"].value`<br>`Document.metadata["date"].as_string` | Document.body.document_date_as_date |
 
 <a id="metadata-jurisdiction"></a>
 
@@ -181,9 +183,9 @@ The date the document was published, usually the date a decision was handed down
 
 The jurisdiction of the court which this decision was made under
 
-| Level         | Sourced from           | Editable | Multiple | Implemented | Access via                   |
-| ------------- | ---------------------- | -------- | -------- | ----------- | ---------------------------- |
-| Document body | Parser (Document body) | No       | No       | Yes         | `Document.body.jurisdiction` |
+| Level         | Sourced from           | Editable | Multiple | Implemented | Access via                                | XML extraction via         |
+| ------------- | ---------------------- | -------- | -------- | ----------- | ----------------------------------------- | -------------------------- |
+| Document body | Parser (Document body) | No       | No       | Yes         | `Document.metadata["jurisdiction"].value` | Document.body.jurisdiction |
 
 <a id="metadata-name"></a>
 
@@ -191,9 +193,9 @@ The jurisdiction of the court which this decision was made under
 
 The title of the document as most commonly used by humans. This _may_ vary from the exact title in the document text, for example by standardising casing.
 
-| Level         | Sourced from                                                | Editable | Multiple | Implemented | Access via           |
-| ------------- | ----------------------------------------------------------- | -------- | -------- | ----------- | -------------------- |
-| Document body | Parser (Document body)<br>Metadata file<br>EUI<br>Stub form | Yes      | No       | Yes         | `Document.body.name` |
+| Level         | Sourced from                                                | Editable | Multiple | Implemented | Access via                        | XML extraction via |
+| ------------- | ----------------------------------------------------------- | -------- | -------- | ----------- | --------------------------------- | ------------------ |
+| Document body | Parser (Document body)<br>Metadata file<br>EUI<br>Stub form | Yes      | No       | Yes         | `Document.metadata["name"].value` | Document.body.name |
 
 <a id="metadata-cite"></a>
 

--- a/scripts/build_document_metadata_table
+++ b/scripts/build_document_metadata_table
@@ -31,6 +31,8 @@ def format_header(key: str) -> str:
         return "Sourced from"
     if key == "access":
         return "Access via"
+    if key == "extraction":
+        return "XML extraction via"
     return key.replace("_", " ").replace("-", " ").title()
 
 
@@ -95,6 +97,16 @@ def normalise_rows(raw_data: object) -> list[dict[str, object]]:
     raise ValueError(msg)
 
 
+STANDARD_DETAIL_FIELDS = ("level", "sources", "editable", "multiple", "implemented", "access", "extraction")
+RESERVED_DETAIL_FIELDS = {"_metadata_key", "name", "description", *STANDARD_DETAIL_FIELDS}
+
+
+def detail_field_keys_for_row(row: dict[str, object]) -> list[str]:
+    detail_field_keys = [key for key in STANDARD_DETAIL_FIELDS if key in row]
+    detail_field_keys.extend(key for key in row if key not in RESERVED_DETAIL_FIELDS)
+    return detail_field_keys
+
+
 def build_table(rows: list[dict[str, object]]) -> str:
     if not rows:
         summary = render_markdown_table(
@@ -129,23 +141,7 @@ def build_table(rows: list[dict[str, object]]) -> str:
         else:
             detail_lines.append("_No description provided._")
 
-        detail_field_keys: list[str] = []
-        if "level" in row:
-            detail_field_keys.append("level")
-        if "sources" in row:
-            detail_field_keys.append("sources")
-        if "editable" in row:
-            detail_field_keys.append("editable")
-        if "multiple" in row:
-            detail_field_keys.append("multiple")
-        if "implemented" in row:
-            detail_field_keys.append("implemented")
-        detail_field_keys.extend(
-            key
-            for key in row
-            if key
-            not in {"_metadata_key", "name", "description", "level", "sources", "editable", "multiple", "implemented"}
-        )
+        detail_field_keys = detail_field_keys_for_row(row)
 
         if detail_field_keys:
             detail_table_rows = [

--- a/scripts/build_document_metadata_table
+++ b/scripts/build_document_metadata_table
@@ -49,7 +49,7 @@ def markdown_escape(value: object) -> str:
 
 
 def render_detail_value(key: str, value: object) -> str:
-    if key != "access":
+    if key not in ("access", "extraction"):
         return markdown_escape(value)
 
     if isinstance(value, Sequence) and not isinstance(value, str):

--- a/scripts/document-metadata.yml
+++ b/scripts/document-metadata.yml
@@ -10,7 +10,8 @@ name:
   editable: true
   multiple: false
   implemented: true
-  access: Document.body.name
+  access: Document.metadata["name"].value
+  extraction: Document.body.name
 
 cite:
   name: NCN
@@ -38,7 +39,8 @@ court:
   editable: true
   multiple: false
   implemented: true
-  access: Document.body.court
+  access: Document.metadata["court"].value
+  extraction: Document.body.court
 
 jurisdiction:
   name: Jurisdiction
@@ -49,7 +51,8 @@ jurisdiction:
   editable: false
   multiple: false
   implemented: true
-  access: Document.body.jurisdiction
+  access: Document.metadata["jurisdiction"].value
+  extraction: Document.body.jurisdiction
 
 categories:
   name: Categories
@@ -59,9 +62,10 @@ categories:
     - Parser (Document body)
     - Metadata file
   editable: false
-  multiple: false
+  multiple: true
   implemented: true
-  access: Document.body.categories
+  access: Document.metadata["categories"].values
+  extraction: Document.body.categories
 
 case_number:
   name: Case number
@@ -73,7 +77,8 @@ case_number:
   editable: false
   multiple: false
   implemented: true
-  access: Document.body.case_number
+  access: Document.metadata["case_number"].value
+  extraction: Document.body.case_number
 
 date:
   name: Judgment date
@@ -87,7 +92,11 @@ date:
   editable: true
   multiple: false
   implemented: true
-  access: Document.body.document_date_as_string
+  access:
+    - Document.metadata["date"].value
+    - Document.metadata["date"].as_string
+  extraction:
+    - Document.body.document_date_as_date
 
 parties:
   name: Parties
@@ -249,7 +258,7 @@ document_first_published_datetime:
     - Ingester
   editable: false
   multiple: false
-  implemented: yes
+  implemented: true
   access: Document.first_published_datetime
 
 document_latest_published_datetime:
@@ -261,5 +270,4 @@ document_latest_published_datetime:
     - Ingester
   editable: false
   multiple: false
-  implemented: yes
-  access: Document.first_published_datetime
+  implemented: false


### PR DESCRIPTION
- Update the YAML to detail changes in our new `metadata`-based layer
- Add an `extraction` field to the metadata table builder to detail where we get the actual value from, rather than how we should access it in code
- Fixes:
  - `categories` is now multiple
  - Correct `document_latest_published_datetime` implementation
  - `implemented` are now all booleans