### PR TITLE
[FCLC-2101] Use attribute access for Document.metadata registry

### DIFF
--- a/doc/document-metadata.md
+++ b/doc/document-metadata.md
@@ -2,7 +2,7 @@
 
 This document lists all the types of metadata which can be associated with a document, if that metadata exists at the level of document, submission or version, how to access that metadata, how that metadata is sourced, and if that metadata should be considered editable.
 
-For document body metadata that is exposed through the API client, use `Document.metadata` as the standard access layer. Each entry is a typed metadata object (for example `NameMetadata`) whose properties delegate to the underlying XML extraction on `Document.body`. The `Document.body` paths remain the implementation layer for reading values directly from the Akoma Ntoso XML.
+For document body metadata that is exposed through the API client, use `Document.metadata` as the standard access layer. Each field is a typed metadata object on `DocumentMetadataRegistry` (for example `document.metadata.name.value`) whose properties delegate to the underlying XML extraction on `Document.body`. The `Document.body` paths remain the implementation layer for reading values directly from the Akoma Ntoso XML.
 
 <!-- Begin document metadata table -->
 <!-- Generated from scripts/build_document_metadata_table using scripts/document-metadata.yml. Do not edit manually. -->
@@ -43,9 +43,9 @@ For document body metadata that is exposed through the API client, use `Document
 
 The case number for the case this document relates to.
 
-| Level         | Sourced from                            | Editable | Multiple | Implemented | Access via                               | XML extraction via          |
-| ------------- | --------------------------------------- | -------- | -------- | ----------- | ---------------------------------------- | --------------------------- |
-| Document body | Parser (Document body)<br>Metadata file | No       | No       | Yes         | `Document.metadata["case_number"].value` | `Document.body.case_number` |
+| Level         | Sourced from                            | Editable | Multiple | Implemented | Access via                            | XML extraction via          |
+| ------------- | --------------------------------------- | -------- | -------- | ----------- | ------------------------------------- | --------------------------- |
+| Document body | Parser (Document body)<br>Metadata file | No       | No       | Yes         | `Document.metadata.case_number.value` | `Document.body.case_number` |
 
 <a id="metadata-categories"></a>
 
@@ -53,9 +53,9 @@ The case number for the case this document relates to.
 
 Categories under which this document falls
 
-| Level         | Sourced from                            | Editable | Multiple | Implemented | Access via                               | XML extraction via         |
-| ------------- | --------------------------------------- | -------- | -------- | ----------- | ---------------------------------------- | -------------------------- |
-| Document body | Parser (Document body)<br>Metadata file | No       | Yes      | Yes         | `Document.metadata["categories"].values` | `Document.body.categories` |
+| Level         | Sourced from                            | Editable | Multiple | Implemented | Access via                            | XML extraction via         |
+| ------------- | --------------------------------------- | -------- | -------- | ----------- | ------------------------------------- | -------------------------- |
+| Document body | Parser (Document body)<br>Metadata file | No       | Yes      | Yes         | `Document.metadata.categories.values` | `Document.body.categories` |
 
 <a id="metadata-court"></a>
 
@@ -63,9 +63,9 @@ Categories under which this document falls
 
 The court which published this document. "Court" here means "any body capable of issuing a legally binding decision".
 
-| Level         | Sourced from                                                | Editable | Multiple | Implemented | Access via                         | XML extraction via    |
-| ------------- | ----------------------------------------------------------- | -------- | -------- | ----------- | ---------------------------------- | --------------------- |
-| Document body | Parser (Document body)<br>Metadata file<br>EUI<br>Stub form | Yes      | No       | Yes         | `Document.metadata["court"].value` | `Document.body.court` |
+| Level         | Sourced from                                                | Editable | Multiple | Implemented | Access via                      | XML extraction via    |
+| ------------- | ----------------------------------------------------------- | -------- | -------- | ----------- | ------------------------------- | --------------------- |
+| Document body | Parser (Document body)<br>Metadata file<br>EUI<br>Stub form | Yes      | No       | Yes         | `Document.metadata.court.value` | `Document.body.court` |
 
 <a id="metadata-documentfirstingestionafterlatestpublicationdatetime"></a>
 
@@ -173,9 +173,9 @@ A list of the names of the judges (or equivalent for the body) involved in any p
 
 The date the document was published, usually the date a decision was handed down.
 
-| Level         | Sourced from                                                | Editable | Multiple | Implemented | Access via                                                                 | XML extraction via                    |
-| ------------- | ----------------------------------------------------------- | -------- | -------- | ----------- | -------------------------------------------------------------------------- | ------------------------------------- |
-| Document body | Parser (Document body)<br>Metadata file<br>EUI<br>Stub form | Yes      | No       | Yes         | `Document.metadata["date"].value`<br>`Document.metadata["date"].as_string` | `Document.body.document_date_as_date` |
+| Level         | Sourced from                                                | Editable | Multiple | Implemented | Access via                                                           | XML extraction via                    |
+| ------------- | ----------------------------------------------------------- | -------- | -------- | ----------- | -------------------------------------------------------------------- | ------------------------------------- |
+| Document body | Parser (Document body)<br>Metadata file<br>EUI<br>Stub form | Yes      | No       | Yes         | `Document.metadata.date.value`<br>`Document.metadata.date.as_string` | `Document.body.document_date_as_date` |
 
 <a id="metadata-jurisdiction"></a>
 
@@ -183,9 +183,9 @@ The date the document was published, usually the date a decision was handed down
 
 The jurisdiction of the court which this decision was made under
 
-| Level         | Sourced from           | Editable | Multiple | Implemented | Access via                                | XML extraction via           |
-| ------------- | ---------------------- | -------- | -------- | ----------- | ----------------------------------------- | ---------------------------- |
-| Document body | Parser (Document body) | No       | No       | Yes         | `Document.metadata["jurisdiction"].value` | `Document.body.jurisdiction` |
+| Level         | Sourced from           | Editable | Multiple | Implemented | Access via                             | XML extraction via           |
+| ------------- | ---------------------- | -------- | -------- | ----------- | -------------------------------------- | ---------------------------- |
+| Document body | Parser (Document body) | No       | No       | Yes         | `Document.metadata.jurisdiction.value` | `Document.body.jurisdiction` |
 
 <a id="metadata-name"></a>
 
@@ -193,9 +193,9 @@ The jurisdiction of the court which this decision was made under
 
 The title of the document as most commonly used by humans. This _may_ vary from the exact title in the document text, for example by standardising casing.
 
-| Level         | Sourced from                                                | Editable | Multiple | Implemented | Access via                        | XML extraction via   |
-| ------------- | ----------------------------------------------------------- | -------- | -------- | ----------- | --------------------------------- | -------------------- |
-| Document body | Parser (Document body)<br>Metadata file<br>EUI<br>Stub form | Yes      | No       | Yes         | `Document.metadata["name"].value` | `Document.body.name` |
+| Level         | Sourced from                                                | Editable | Multiple | Implemented | Access via                     | XML extraction via   |
+| ------------- | ----------------------------------------------------------- | -------- | -------- | ----------- | ------------------------------ | -------------------- |
+| Document body | Parser (Document body)<br>Metadata file<br>EUI<br>Stub form | Yes      | No       | Yes         | `Document.metadata.name.value` | `Document.body.name` |
 
 <a id="metadata-cite"></a>
 

--- a/scripts/document-metadata.yml
+++ b/scripts/document-metadata.yml
@@ -10,7 +10,7 @@ name:
   editable: true
   multiple: false
   implemented: true
-  access: Document.metadata["name"].value
+  access: Document.metadata.name.value
   extraction: Document.body.name
 
 cite:
@@ -39,7 +39,7 @@ court:
   editable: true
   multiple: false
   implemented: true
-  access: Document.metadata["court"].value
+  access: Document.metadata.court.value
   extraction: Document.body.court
 
 jurisdiction:
@@ -51,7 +51,7 @@ jurisdiction:
   editable: false
   multiple: false
   implemented: true
-  access: Document.metadata["jurisdiction"].value
+  access: Document.metadata.jurisdiction.value
   extraction: Document.body.jurisdiction
 
 categories:
@@ -64,7 +64,7 @@ categories:
   editable: false
   multiple: true
   implemented: true
-  access: Document.metadata["categories"].values
+  access: Document.metadata.categories.values
   extraction: Document.body.categories
 
 case_number:
@@ -77,7 +77,7 @@ case_number:
   editable: false
   multiple: false
   implemented: true
-  access: Document.metadata["case_number"].value
+  access: Document.metadata.case_number.value
   extraction: Document.body.case_number
 
 date:
@@ -93,8 +93,8 @@ date:
   multiple: false
   implemented: true
   access:
-    - Document.metadata["date"].value
-    - Document.metadata["date"].as_string
+    - Document.metadata.date.value
+    - Document.metadata.date.as_string
   extraction:
     - Document.body.document_date_as_date
 


### PR DESCRIPTION
## Summary
- Update documented `Document.metadata` access paths from string-key mapping style (`metadata["name"].value`) to typed attribute style (`metadata.name.value`)
- Regenerates `doc/document-metadata.md` from the YAML source

Pairs with the API client change that turns `DocumentMetadataRegistry` into a class with typed attributes.

## Test plan
- [ ] Confirm generated tables show backtick-wrapped attribute paths
- [ ] Spot-check name/court/date/categories/case_number/jurisdiction entries