### PR TITLE
docs: note plural-canonical categories metadata key

### DIFF
--- a/doc/document-metadata.md
+++ b/doc/document-metadata.md
@@ -51,7 +51,7 @@ The case number for the case this document relates to.
 
 ### Categories
 
-Categories under which this document falls
+Categories under which this document falls. Metadata claims use the name `categories` (legacy `category` claims are still resolved by the API client). The deprecated Python facade key `Document.metadata["category"]` aliases to `Document.metadata["categories"]`.
 
 | Level         | Sourced from                            | Editable | Multiple | Implemented | Access via                               | XML extraction via         |
 | ------------- | --------------------------------------- | -------- | -------- | ----------- | ---------------------------------------- | -------------------------- |

--- a/scripts/document-metadata.yml
+++ b/scripts/document-metadata.yml
@@ -56,7 +56,11 @@ jurisdiction:
 
 categories:
   name: Categories
-  description: Categories under which this document falls
+  description: >-
+    Categories under which this document falls. Metadata claims use the name
+    `categories` (legacy `category` claims are still resolved by the API client).
+    The deprecated Python facade key `Document.metadata["category"]` aliases to
+    `Document.metadata["categories"]`.
   level: Document body
   sources:
     - Parser (Document body)


### PR DESCRIPTION
## Summary
- Update the Categories entry in `document-metadata.yml` to state that claim / API access uses plural `categories`
- Note that legacy `category` claims and `Document.metadata["category"]` remain supported via the API client
- Regenerate `doc/document-metadata.md`

Pairs with API client change: https://github.com/nationalarchives/ds-caselaw-custom-api-client/pull/1982

 intentionally does **not** amend historical ADR examples.

## Test plan
- [x] `python3 scripts/build_document_metadata_table`
- [ ] Review rendered Categories section on the PR